### PR TITLE
Show loading when user post new toot

### DIFF
--- a/src/renderer/components/TimelineSpace/Modals/NewToot.vue
+++ b/src/renderer/components/TimelineSpace/Modals/NewToot.vue
@@ -103,15 +103,25 @@ export default {
           media_ids: this.attachedMedias.map((m) => { return m.id })
         })
       }
+
+      const loading = this.$loading({
+        lock: true,
+        text: 'Loading',
+        spinner: 'el-icon-loading',
+        background: 'rgba(0, 0, 0, 0.7)'
+      })
+
       this.$store.dispatch('TimelineSpace/Modals/NewToot/postToot', form)
         .then(() => {
           this.close()
+          loading.close()
           this.$message({
             message: 'Toot',
             type: 'success'
           })
         })
         .catch(() => {
+          loading.close()
           this.$message({
             message: 'Could not toot',
             type: 'error'


### PR DESCRIPTION
I found that when user post a new toot with a slow network, they maybe double click the toot button and post duplicate toot to timeline. In order to avoid this problem, I add a loading screen to NewTool.vue.

