### PR TITLE
fix: Block toot when new toot modal is closed

### DIFF
--- a/src/renderer/components/TimelineSpace/Modals/NewToot.vue
+++ b/src/renderer/components/TimelineSpace/Modals/NewToot.vue
@@ -108,6 +108,9 @@ export default {
       this.$store.dispatch('TimelineSpace/Modals/NewToot/changeModal', false)
     },
     toot () {
+      if (!this.newTootModal) {
+        return
+      }
       if (this.status.length <= 0 || this.status.length >= 500) {
         return this.$message({
           message: 'Toot length should be 1 to 500',


### PR DESCRIPTION
Show error message when I put `Ctrl + Enter`, although the modal has been closed.