### PR TITLE
Updated package lists to update vue-router & vuex versions to 3.0.1.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15804,9 +15804,9 @@
       }
     },
     "vue-router": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-2.8.1.tgz",
-      "integrity": "sha512-MC4jacHBhTPKtmcfzvaj2N7g6jgJ/Z/eIjZdt+yUaUOM1iKC0OUIlO/xCtz6OZFFTNUJs/1YNro2GN/lE+nOXA=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.0.1.tgz",
+      "integrity": "sha512-vLLoY452L+JBpALMP5UHum9+7nzR9PeIBCghU9ZtJ1eWm6ieUI8Zb/DI3MYxH32bxkjzYV1LRjNv4qr8d+uX/w=="
     },
     "vue-shortkey": {
       "version": "3.1.0",
@@ -15843,9 +15843,9 @@
       "dev": true
     },
     "vuex": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/vuex/-/vuex-2.5.0.tgz",
-      "integrity": "sha512-5oJPOJySBgSgSzoeO+gZB/BbN/XsapgIF6tz34UwJqnGZMQurzIO3B4KIBf862gfc9ya+oduY5sSkq+5/oOilQ=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.0.1.tgz",
+      "integrity": "sha512-wLoqz0B7DSZtgbWL1ShIBBCjv22GV5U+vcBFox658g6V0s4wZV9P4YjCNyoHSyIBpj1f29JBoNQIqD82cR4O3w=="
     },
     "vuex-router-sync": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -99,9 +99,9 @@
     "vue-awesome": "^2.3.5",
     "vue-electron": "^1.0.6",
     "vue-popperjs": "^1.2.6",
-    "vue-router": "^2.5.3",
+    "vue-router": "^3.0.1",
     "vue-shortkey": "^3.1.0",
-    "vuex": "^2.3.1",
+    "vuex": "^3.0.1",
     "vuex-router-sync": "^5.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I noticed a couple of warnings about vue-router & vuex being the wrong versions when building whalebird, so I've installed the updated versions and thus modified the package.json & package-lock.json files.

As I only build on Linux, I have no idea if there would be conflicts with builds on other OSs.