### PR TITLE
Allow reload pages with shortcut keys

### DIFF
--- a/src/renderer/components/TimelineSpace/Contents/Favourites.vue
+++ b/src/renderer/components/TimelineSpace/Contents/Favourites.vue
@@ -1,5 +1,7 @@
 <template>
   <div id="favourites">
+    <div v-shortkey="{linux: ['ctrl', 'r'], mac: ['meta', 'r']}" @shortkey="reload()">
+    </div>
     <div class="fav" v-for="message in favourites" v-bind:key="message.id">
       <toot :message="message" v-on:update="updateToot" v-on:delete="deleteToot"></toot>
     </div>
@@ -69,6 +71,38 @@ export default {
             })
           })
       }
+    },
+    async reload () {
+      const loading = this.$loading({
+        lock: true,
+        text: 'Loading',
+        spinner: 'el-icon-loading',
+        background: 'rgba(0, 0, 0, 0.7)'
+      })
+      const account = await this.$store.dispatch('TimelineSpace/localAccount', this.$route.params.id).catch(() => {
+        this.$message({
+          message: 'Could not find account',
+          type: 'error'
+        })
+      })
+
+      await this.$store.dispatch('TimelineSpace/stopUserStreaming')
+      await this.$store.dispatch('TimelineSpace/stopLocalStreaming')
+
+      await this.$store.dispatch('TimelineSpace/Contents/Home/fetchTimeline', account)
+      await this.$store.dispatch('TimelineSpace/Contents/Local/fetchLocalTimeline', account)
+      await this.$store.dispatch('TimelineSpace/Contents/Favourites/fetchFavourites', account)
+        .catch(() => {
+          loading.close()
+          this.$message({
+            message: 'Could not fetch favourites',
+            type: 'error'
+          })
+        })
+
+      this.$store.dispatch('TimelineSpace/startUserStreaming', account)
+      this.$store.dispatch('TimelineSpace/startLocalStreaming', account)
+      loading.close()
     }
   }
 }

--- a/src/renderer/components/TimelineSpace/Contents/Lists/Show.vue
+++ b/src/renderer/components/TimelineSpace/Contents/Lists/Show.vue
@@ -1,6 +1,8 @@
 <template>
 <div name="list">
   <div class="unread">{{ unread.length > 0 ? unread.length : '' }}</div>
+  <div v-shortkey="{linux: ['ctrl', 'r'], mac: ['meta', 'r']}" @shortkey="reload()">
+  </div>
   <transition-group name="timeline" tag="div">
     <div class="list-timeline" v-for="message in timeline" v-bind:key="message.id">
       <toot :message="message" v-on:update="updateToot" v-on:delete="deleteToot"></toot>
@@ -107,6 +109,45 @@ export default {
         this.$store.commit('TimelineSpace/Contents/Lists/Show/changeHeading', true)
         this.$store.commit('TimelineSpace/Contents/Lists/Show/mergeTimeline')
       }
+    },
+    async reload () {
+      const loading = this.$loading({
+        lock: true,
+        text: 'Loading',
+        spinner: 'el-icon-loading',
+        background: 'rgba(0, 0, 0, 0.7)'
+      })
+      const account = await this.$store.dispatch('TimelineSpace/localAccount', this.$route.params.id).catch(() => {
+        this.$message({
+          message: 'Could not find account',
+          type: 'error'
+        })
+      })
+
+      await this.$store.dispatch('TimelineSpace/stopUserStreaming')
+      await this.$store.dispatch('TimelineSpace/stopLocalStreaming')
+      await this.$store.dispatch('TimelineSpace/Contents/Lists/Show/stopStreaming')
+
+      await this.$store.dispatch('TimelineSpace/Contents/Home/fetchTimeline', account)
+      await this.$store.dispatch('TimelineSpace/Contents/Local/fetchLocalTimeline', account)
+      await this.$store.dispatch('TimelineSpace/Contents/Lists/Show/fetchTimeline', this.list_id)
+        .catch(() => {
+          this.$message({
+            message: 'Could not fetch timeline',
+            type: 'error'
+          })
+        })
+
+      this.$store.dispatch('TimelineSpace/startUserStreaming', account)
+      this.$store.dispatch('TimelineSpace/startLocalStreaming', account)
+      this.$store.dispatch('TimelineSpace/Contents/Lists/Show/startStreaming', this.list_id)
+        .catch(() => {
+          this.$message({
+            message: 'Failed to restart streaming',
+            type: 'error'
+          })
+        })
+      loading.close()
     }
   }
 }

--- a/src/renderer/components/TimelineSpace/Contents/Local.vue
+++ b/src/renderer/components/TimelineSpace/Contents/Local.vue
@@ -1,6 +1,8 @@
 <template>
   <div id="local">
     <div class="unread">{{ unread.length > 0 ? unread.length : '' }}</div>
+    <div v-shortkey="{linux: ['ctrl', 'r'], mac: ['meta', 'r']}" @shortkey="reload()">
+    </div>
     <transition-group name="timeline" tag="div">
       <div class="local-timeline" v-for="message in timeline" v-bind:key="message.id">
         <toot :message="message" v-on:update="updateToot" v-on:delete="deleteToot"></toot>
@@ -69,6 +71,43 @@ export default {
         this.$store.commit('TimelineSpace/Contents/Local/changeHeading', true)
         this.$store.commit('TimelineSpace/Contents/Local/mergeTimeline')
       }
+    },
+    async reload () {
+      const loading = this.$loading({
+        lock: true,
+        text: 'Loading',
+        spinner: 'el-icon-loading',
+        background: 'rgba(0, 0, 0, 0.7)'
+      })
+      const account = await this.$store.dispatch('TimelineSpace/localAccount', this.$route.params.id).catch(() => {
+        this.$message({
+          message: 'Could not find account',
+          type: 'error'
+        })
+      })
+      await this.$store.dispatch('TimelineSpace/stopUserStreaming')
+      await this.$store.dispatch('TimelineSpace/stopLocalStreaming')
+
+      await this.$store.dispatch('TimelineSpace/Contents/Home/fetchTimeline', account)
+      await this.$store.dispatch('TimelineSpace/Contents/Local/fetchLocalTimeline', account)
+        .catch(() => {
+          loading.close()
+          this.$message({
+            message: 'Could not fetch local timeline',
+            type: 'error'
+          })
+        })
+
+      this.$store.dispatch('TimelineSpace/startUserStreaming', account)
+      this.$store.dispatch('TimelineSpace/startLocalStreaming', account)
+        .catch(() => {
+          loading.close()
+          this.$message({
+            message: 'Failed to restart streaming',
+            type: 'error'
+          })
+        })
+      loading.close()
     }
   }
 }

--- a/src/renderer/components/TimelineSpace/Contents/Notifications.vue
+++ b/src/renderer/components/TimelineSpace/Contents/Notifications.vue
@@ -1,6 +1,8 @@
 <template>
   <div id="notifications">
     <div class="unread">{{ unread.length > 0 ? unread.length : '' }}</div>
+    <div v-shortkey="{linux: ['ctrl', 'r'], mac: ['meta', 'r']}" @shortkey="reload()">
+    </div>
     <transition-group name="timeline" tag="div">
       <div class="notifications" v-for="message in notifications" v-bind:key="message.id">
         <notification :message="message"></notification>
@@ -64,6 +66,37 @@ export default {
         this.$store.commit('TimelineSpace/Contents/Notifications/changeHeading', true)
         this.$store.commit('TimelineSpace/Contents/Notifications/mergeNotifications')
       }
+    },
+    async reload () {
+      const loading = this.$loading({
+        lock: true,
+        text: 'Loading',
+        spinner: 'el-icon-loading',
+        background: 'rgba(0, 0, 0, 0.7)'
+      })
+      const account = await this.$store.dispatch('TimelineSpace/localAccount', this.$route.params.id).catch(() => {
+        this.$message({
+          message: 'Could not find account',
+          type: 'error'
+        })
+      })
+      await this.$store.dispatch('TimelineSpace/stopUserStreaming')
+      await this.$store.dispatch('TimelineSpace/stopLocalStreaming')
+
+      await this.$store.dispatch('TimelineSpace/Contents/Home/fetchTimeline', account)
+      await this.$store.dispatch('TimelineSpace/Contents/Local/fetchLocalTimeline', account)
+      await this.$store.dispatch('TimelineSpace/Contents/Notifications/fetchNotifications', account)
+        .catch(() => {
+          loading.close()
+          this.$message({
+            message: 'Could not fetch notifications',
+            type: 'error'
+          })
+        })
+
+      this.$store.dispatch('TimelineSpace/startUserStreaming', account)
+      this.$store.dispatch('TimelineSpace/startLocalStreaming', account)
+      loading.close()
     }
   }
 }


### PR DESCRIPTION
Close #351 

Add shortcut keys, `Cmd + r` and `Ctrl + r`, to reload pages in Whablebird.