### PR TITLE
Hide follower menue for own user account

### DIFF
--- a/src/renderer/components/TimelineSpace/Contents/SideBar/AccountProfile.vue
+++ b/src/renderer/components/TimelineSpace/Contents/SideBar/AccountProfile.vue
@@ -6,7 +6,7 @@
      element-loading-background="rgba(0, 0, 0, 0.8)">
   <div class="header-background" v-bind:style="{ backgroundImage: 'url(' + account.header + ')' }">
     <div class="header">
-      <div class="follow-follower" v-if="relationship !== null && relationship !== ''">
+      <div class="follow-follower" v-if="relationship !== null && relationship !== '' && account.username!==user.username">
         <div class="follower-status">
           <span class="status" v-if="relationship.followed_by">{{ $t('side_bar.account_profile.follows_you') }}</span>
           <span class="status" v-else>{{ $t('side_bar.account_profile.doesnt_follow_you') }}</span>
@@ -18,7 +18,7 @@
           <div v-else-if="relationship.requested">
             <icon name="hourglass" scale="1.5"></icon>
           </div>
-          <div v-else-if="account.username!==user.username" class="follow" @click="follow(account)">
+          <div v-else class="follow" @click="follow(account)">
             <icon name="user-plus" scale="1.5"></icon>
           </div>
         </div>

--- a/src/renderer/components/TimelineSpace/Contents/SideBar/AccountProfile.vue
+++ b/src/renderer/components/TimelineSpace/Contents/SideBar/AccountProfile.vue
@@ -18,7 +18,7 @@
           <div v-else-if="relationship.requested">
             <icon name="hourglass" scale="1.5"></icon>
           </div>
-          <div v-else class="follow" @click="follow(account)">
+          <div v-else-if="account.username!==user.username" class="follow" @click="follow(account)">
             <icon name="user-plus" scale="1.5"></icon>
           </div>
         </div>
@@ -104,6 +104,7 @@ export default {
   computed: {
     ...mapState({
       account: state => state.TimelineSpace.Contents.SideBar.AccountProfile.account,
+      user: state => state.TimelineSpace.account,
       relationship: state => state.TimelineSpace.Contents.SideBar.AccountProfile.relationship,
       loading: state => state.TimelineSpace.Contents.SideBar.AccountProfile.loading,
       theme: (state) => {


### PR DESCRIPTION
Add the own user to the state and compare the account of the profile view with the own user.
If we render the own user, we don`t need to render the whole follower menue.

Fixes: #491