### PR TITLE
Fix some minor typos

### DIFF
--- a/src/config/locales/de/translation.json
+++ b/src/config/locales/de/translation.json
@@ -3,7 +3,7 @@
     "application": {
       "name": "Whalebird",
       "about": "Über Whalebird",
-      "preferences": "Einstellungen...",
+      "preferences": "Einstellungen …",
       "services": "Dienste",
       "hide": "Whalebird verstecken",
       "hide_others": "Andere verstecken",
@@ -106,7 +106,7 @@
     },
     "language": {
       "title": "Sprache",
-      "display_language": "sprache",
+      "display_language": "Sprache",
       "notice": "Erfordert Neustart",
       "confirm": {
         "title": "Warnung",
@@ -158,7 +158,7 @@
       "manage_list_memberships": "Listen-Mitgliedschaften verwalten",
       "toots": "Toots",
       "follows": "Follows",
-      "followers": "Followers"
+      "followers": "Follower"
     }
   },
   "hashtag": {


### PR DESCRIPTION
Uses typographically correct ellipse,
fixes capitalization of noun,
uses German expression Follower (plural) instead of English Followers (according to Duden,  dictionary of the German language, both is allowed but Follower more common).