### PR TITLE
Corrects some translations and changes time to Time Since

### DIFF
--- a/src/config/locales/en/translation.json
+++ b/src/config/locales/en/translation.json
@@ -98,7 +98,7 @@
       "domain": "Domain",
       "association": "Association",
       "order": "Order",
-      "remove_association": "Remove assocication",
+      "remove_association": "Remove association",
       "remove_all_associations": "Remove all associations",
       "confirm": "Confirm",
       "cancel": "Cancel",
@@ -123,7 +123,7 @@
       "status": "What is on your mind?",
       "cancel": "Cancel",
       "toot": "Toot",
-      "close_confirm": "Are you sure to close new toot?",
+      "close_confirm": "Are you sure you want to close new toot?",
       "close_confirm_ok": "OK",
       "close_confirm_cancel": "Cancel"
     },
@@ -181,7 +181,7 @@
     "login": "Login"
   },
   "authorize": {
-    "manually_1": "Now authorization page is opened in your browser.",
+    "manually_1": "The authorization page should now be opened in your browser.",
     "manually_2": "If it is not opened, please open the following URL manually.",
     "code_label": "Please paste authorization code from your browser:",
     "submit": "Submit"

--- a/src/renderer/components/TimelineSpace/Contents/Cards/Toot.vue
+++ b/src/renderer/components/TimelineSpace/Contents/Cards/Toot.vue
@@ -13,9 +13,9 @@
           <span class="display-name">{{ username(originalMessage(message).account) }}</span>
           <span class="acct">{{ accountName(originalMessage(message).account) }}</span>
         </div>
-        <div class="timestamp">
-          {{ parseDatetime(originalMessage(message).created_at) }}
-        </div>
+      <div class="timestamp" v-bind:title="parseDatetime(originalMessage(message).created_at)">
+          {{ parseFuzzyDatetime(originalMessage(message).created_at) }}
+      </div>
         <div class="clearfix"></div>
       </div>
       <div class="content-wrapper">
@@ -175,6 +175,9 @@ export default {
     },
     parseDatetime (datetime) {
       return moment(datetime).format('YYYY-MM-DD HH:mm:ss')
+    },
+    parseFuzzyDatetime (datetime) {
+      return moment(datetime).fromNow()
     },
     tootClick (e) {
       if (isTag(e.target)) {
@@ -406,7 +409,6 @@ export default {
         text-align: right;
         width: 100%;
         color: #909399;
-        flota: right;
       }
     }
 


### PR DESCRIPTION
* Corrects spelling in some EN translation
* Corrects grammar in EN translation
* Removes misspelled style from element (correcting it breaks layout)
* Moves the full datetime to the title attribute and instead shows time since post

Implements feature request #527 