### PR TITLE
Fix timeline header width when account sidebar is collapsed

### DIFF
--- a/src/renderer/components/TimelineSpace.vue
+++ b/src/renderer/components/TimelineSpace.vue
@@ -185,11 +185,17 @@ export default {
   box-sizing: border-box;
 
   .header {
-    width: calc(100% - 141px);
+    width: calc(100% - 64px);
     position: fixed;
     top: 0;
     height: 48px;
     border-bottom: solid 1px var(--theme-border-color);
+  }
+}
+
+.with-global-header {
+  .page-narrow .header{
+    width: calc(100% - 65px - 64px);
   }
 }
 

--- a/src/renderer/components/TimelineSpace.vue
+++ b/src/renderer/components/TimelineSpace.vue
@@ -194,7 +194,7 @@ export default {
 }
 
 .with-global-header {
-  .page-narrow .header{
+  .page-narrow .header {
     width: calc(100% - 65px - 64px);
   }
 }


### PR DESCRIPTION
This pull request adjusts the `.page-narrow .header` SCSS in `TimelineSpace.vue` so that it matches the timeline's width both with the account sidebar open and when collapsed.
I tested this in MacOS Sierra and Windows 7 x64.