### PR TITLE
Always clear timeline between switches/refreshes

### DIFF
--- a/src/renderer/components/TimelineSpace/Contents/SideBar/AccountProfile/Timeline.vue
+++ b/src/renderer/components/TimelineSpace/Contents/SideBar/AccountProfile/Timeline.vue
@@ -36,6 +36,7 @@ export default {
   },
   watch: {
     account: function (newAccount, oldAccount) {
+      this.$store.dispatch('TimelineSpace/Contents/SideBar/AccountProfile/Timeline/clearTimeline')
       this.load()
     }
   },

--- a/src/renderer/store/TimelineSpace/Contents/SideBar/AccountProfile/Timeline.js
+++ b/src/renderer/store/TimelineSpace/Contents/SideBar/AccountProfile/Timeline.js
@@ -80,6 +80,9 @@ const Timeline = {
           commit('changeLazyLoading', false)
           throw err
         })
+    },
+    clearTimeline ({ state, commit, rootState }) {
+      commit('updateTimeline', [])
     }
   }
 }

--- a/src/renderer/store/TimelineSpace/Contents/SideBar/TootDetail.js
+++ b/src/renderer/store/TimelineSpace/Contents/SideBar/TootDetail.js
@@ -89,6 +89,8 @@ const TootDetail = {
   },
   actions: {
     changeToot ({ commit, dispatch }, message) {
+      commit('updateAncestors', [])
+      commit('updateDescendants', [])
       commit('changeToot', message)
     },
     fetchToot ({ state, commit, rootState }, message) {


### PR DESCRIPTION
I thought it'd be clearer, UX-wise, to remove unrelated content when changing sidebar toots/profiles.