### PR TITLE
Fix typo in Follow component

### DIFF
--- a/src/renderer/components/molecules/Notification/Follow.vue
+++ b/src/renderer/components/molecules/Notification/Follow.vue
@@ -30,7 +30,7 @@ import FailoverImg from '~/src/renderer/components/atoms/FailoverImg'
 
 export default {
   name: 'follow',
-  componengs: {
+  components: {
     FailoverImg
   },
   props: {


### PR DESCRIPTION
This lets the Follow notification pick up the `FailoverImg` component.