### PR TITLE
Fix Whalebird font stack

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -74,7 +74,7 @@ html, body, #app {
     background-color: #d9e1e8;
   }
 
-  --specified-fonts: 'Noto Sans', 'Noto Sans CJK JP', 'Takaoゴシック', 'Hiragino Kaku Gothic ProN', 'ヒラギノ角ゴ ProN W3', Meiryo, メイリオ, Osaka, 'MS PGothic', arial, helvetica, sans-serif;
+  --specified-fonts: 'Noto Sans', 'Noto Sans CJK JP', 'Takaoゴシック', 'ヒラギノ角ゴ ProN W3', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Helvetica Neue', 'Apple Color Emoji', 'Segoe UI Emoji','Segoe UI Symbol';
 
   font-family: var(--specified-fonts);
 

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -74,7 +74,7 @@ html, body, #app {
     background-color: #d9e1e8;
   }
 
-  --specified-fonts: 'Noto Sans', 'Noto Sans CJK JP', 'Takaoゴシック', 'ヒラギノ角ゴ ProN W3', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Helvetica Neue', 'Apple Color Emoji', 'Segoe UI Emoji','Segoe UI Symbol';
+  --specified-fonts: 'Noto Sans', 'Noto Sans CJK JP', 'Takaoゴシック', 'ヒラギノ角ゴ ProN W3', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Helvetica Neue', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 
   font-family: var(--specified-fonts);
 

--- a/src/renderer/components/TimelineSpace/Modals/NewToot.vue
+++ b/src/renderer/components/TimelineSpace/Modals/NewToot.vue
@@ -309,7 +309,6 @@ export default {
 
       input {
         border-radius: 0;
-        font-family: 'Lato', sans-serif;
 
         &::placeholder {
           color: #c0c4cc;

--- a/src/renderer/components/TimelineSpace/Modals/NewToot/Status.vue
+++ b/src/renderer/components/TimelineSpace/Modals/NewToot/Status.vue
@@ -319,7 +319,6 @@ export default {
     resize: none;
     height: 120px;
     transition: border-color 0.2s cubic-bezier(0.645, 0.045, 9.355, 1);
-    font-family: 'Lato', sans-serif;
 
     &::placeholder {
       color: #c0c4cc;

--- a/src/renderer/utils/fonts.js
+++ b/src/renderer/utils/fonts.js
@@ -2,13 +2,13 @@ export default [
   'Noto Sans',
   'Noto Sans CJK JP',
   'Takaoゴシック',
-  'Hiragino Kaku Gothic ProN',
   'ヒラギノ角ゴ ProN W3',
-  'Meiryo',
-  'メイリオ',
-  'Osaka',
-  'MS PGothic',
-  'arial',
-  'helvetica',
-  'sans-serif'
+  '-apple-system',
+  'BlinkMacSystemFont',
+  'Segoe UI',
+  'Roboto',
+  'Helvetica Neue',
+  'Apple Color Emoji',
+  'Segoe UI Emoji',
+  'Segoe UI Symbol'
 ]


### PR DESCRIPTION
This pull request removes some Japanese and Western language fonts that break emoji composition. I've also removed Lato from the New Toot modal for the same reasons.
Additionally, I've added Bootstrap's font stack as a fallback.
Fixes #708.