### PR TITLE
Fix header length when not using narrow menu

### DIFF
--- a/src/renderer/components/TimelineSpace.vue
+++ b/src/renderer/components/TimelineSpace.vue
@@ -172,7 +172,7 @@ export default {
   box-sizing: border-box;
 
   .header {
-    width: calc(100% - 245px);
+    width: calc(100% - 180px);
     position: fixed;
     top: 0;
     height: 48px;


### PR DESCRIPTION
I forgot in #709 to fix the header when the sidebar menu isn't collapsed.