### PR TITLE
Remove spinner after image has been loaded

### DIFF
--- a/src/renderer/components/atoms/FailoverImg.vue
+++ b/src/renderer/components/atoms/FailoverImg.vue
@@ -4,6 +4,8 @@
   :title="title"
   :alt="alt"
   v-on:error="failover"
+  v-on:load="loading = false"
+  :class="loading ? 'loading' : ''"
   @click="$emit('click')" />
 </template>
 
@@ -46,11 +48,14 @@ export default {
 
 <style lang="scss" scoped>
 img {
-  min-width: 20px;
-  min-height: 20px;
-  background-image: url("../../assets/images/loading-spinner.svg");
-  background-position: center center;
-  background-repeat: no-repeat;
-  background-size: contain;
+  min-width: 1em;
+  min-height: 1em;
+
+  &.loading {
+    background-image: url("../../images/loading-spinner.svg");
+    background-position: center center;
+    background-repeat: no-repeat;
+    background-size: contain;
+  }
 }
 </style>

--- a/src/renderer/components/atoms/FailoverImg.vue
+++ b/src/renderer/components/atoms/FailoverImg.vue
@@ -52,7 +52,7 @@ img {
   min-height: 1em;
 
   &.loading {
-    background-image: url("../../images/loading-spinner.svg");
+    background-image: url("../../assets/images/loading-spinner.svg");
     background-position: center center;
     background-repeat: no-repeat;
     background-size: contain;


### PR DESCRIPTION
This fixes transparent images that still show the spinner beneath them after they've been loaded successfully. I've also fixed an incorrect minimum size when used together with a reblogger's avatar.

Tested with any of the toots by @Curator@mastodon.art.