### PR TITLE
Clear sidebar timeline also when component changed

### DIFF
--- a/src/renderer/components/TimelineSpace/Contents/SideBar/AccountProfile/Timeline.vue
+++ b/src/renderer/components/TimelineSpace/Contents/SideBar/AccountProfile/Timeline.vue
@@ -27,6 +27,7 @@ export default {
     this.load()
   },
   mounted () {
+    this.$store.dispatch('TimelineSpace/Contents/SideBar/AccountProfile/Timeline/clearTimeline')
     document.getElementById('sidebar_scrollable').addEventListener('scroll', this.onScroll)
   },
   destroyed () {


### PR DESCRIPTION
I forgot in #726 to clear the timeline also when changing components (e.g. click on account, then on a toot, then on a different account).