### PR TITLE
Fix moving cursor in CW input

### DIFF
--- a/src/renderer/components/TimelineSpace/Modals/NewToot.vue
+++ b/src/renderer/components/TimelineSpace/Modals/NewToot.vue
@@ -7,7 +7,9 @@
     class="new-toot-modal">
     <el-form v-on:submit.prevent="toot" role="form">
       <div class="spoiler" v-show="showContentWarning">
-        <el-input :placeholder="$t('modals.new_toot.cw')" v-model="spoiler"></el-input>
+        <div class="el-input">
+          <input type="text" class="el-input__inner" :placeholder="$t('modals.new_toot.cw')" v-model="spoiler" v-shortkey.avoid />
+        </div>
       </div>
       <Status
         v-model="status"


### PR DESCRIPTION
It seems that `vue-shortkey` swallows cursor events in the whole modal, not just the `Status` component. This pull request unpacks the `el-input` element for the CW and applies `v-shortkey.avoid` to the input element.