### PR TITLE
Enable searching toots by link

### DIFF
--- a/src/config/locales/de/translation.json
+++ b/src/config/locales/de/translation.json
@@ -274,7 +274,8 @@
   "search": {
     "search": "Suche",
     "account": "Konto",
-    "keyword": "stichwort"
+    "keyword": "stichwort",
+    "toot": "Toot"
   },
   "lists": {
     "index": {

--- a/src/config/locales/en/translation.json
+++ b/src/config/locales/en/translation.json
@@ -295,7 +295,8 @@
     "search": "Search",
     "account": "Account",
     "tag": "Hashtag",
-    "keyword": "keyword"
+    "keyword": "keyword",
+    "toot": "Toot"
   },
   "lists": {
     "index": {

--- a/src/config/locales/fr/translation.json
+++ b/src/config/locales/fr/translation.json
@@ -274,7 +274,8 @@
   "search": {
     "search": "Rechercher",
     "account": "Compte",
-    "keyword": "mot clé"
+    "keyword": "mot clé",
+    "toot": "Pouets"
   },
   "lists": {
     "index": {

--- a/src/config/locales/ja/translation.json
+++ b/src/config/locales/ja/translation.json
@@ -288,7 +288,8 @@
     "search": "検索",
     "account": "アカウント",
     "tag": "ハッシュタグ",
-    "keyword": "キーワード"
+    "keyword": "キーワード",
+    "toot": "トゥート時"
   },
   "lists": {
     "index": {

--- a/src/config/locales/ko/translation.json
+++ b/src/config/locales/ko/translation.json
@@ -274,7 +274,8 @@
   "search": {
     "search": "검색",
     "account": "계정",
-    "keyword": "키워드"
+    "keyword": "키워드",
+    "toot": "툿"
   },
   "lists": {
     "index": {

--- a/src/config/locales/pl/translation.json
+++ b/src/config/locales/pl/translation.json
@@ -274,7 +274,8 @@
   "search": {
     "search": "Szukaj",
     "account": "Konta",
-    "keyword": "Słowo kluczowe"
+    "keyword": "Słowo kluczowe",
+    "toot": "Wpisy"
   },
   "lists": {
     "index": {

--- a/src/renderer/components/TimelineSpace/Contents/Search.vue
+++ b/src/renderer/components/TimelineSpace/Contents/Search.vue
@@ -17,6 +17,7 @@
     <div class="search-result">
       <search-account v-if="target==='account'"></search-account>
       <search-tag v-else-if="target==='tag'"></search-tag>
+      <search-toots v-else-if="target==='toot'"></search-toots>
     </div>
   </div>
 </template>
@@ -25,10 +26,11 @@
 import { mapState } from 'vuex'
 import SearchAccount from './Search/Account'
 import SearchTag from './Search/Tag'
+import SearchToots from './Search/Toots'
 
 export default {
   name: 'search',
-  components: { SearchAccount, SearchTag },
+  components: { SearchAccount, SearchTag, SearchToots },
   data () {
     return {
       target: 'account',
@@ -50,6 +52,10 @@ export default {
           {
             target: 'tag',
             label: this.$t('search.tag')
+          },
+          {
+            target: 'toot',
+            label: this.$t('search.toot')
           }
         ]
       }
@@ -69,6 +75,15 @@ export default {
           break
         case 'tag':
           this.$store.dispatch('TimelineSpace/Contents/Search/Tag/search', `#${this.query}`)
+            .catch(() => {
+              this.$message({
+                message: this.$t('message.search_error'),
+                type: 'error'
+              })
+            })
+          break
+        case 'toot':
+          this.$store.dispatch('TimelineSpace/Contents/Search/Toots/search', this.query)
             .catch(() => {
               this.$message({
                 message: this.$t('message.search_error'),

--- a/src/renderer/components/TimelineSpace/Contents/Search/Toots.vue
+++ b/src/renderer/components/TimelineSpace/Contents/Search/Toots.vue
@@ -1,0 +1,28 @@
+<template>
+  <div id="search_account">
+    <div v-bind:key="message.uri + message.id" v-for="message in results">
+      <toot :message="message"></toot>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex'
+import Toot from '~/src/renderer/components/molecules/Toot'
+
+export default {
+  name: 'search-account',
+  components: { Toot },
+  computed: {
+    ...mapState({
+      results: state => state.TimelineSpace.Contents.Search.Toots.results
+    })
+  },
+  destroyed () {
+    this.$store.commit('TimelineSpace/Contents/Search/Toots/updateResults', [])
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/src/renderer/store/TimelineSpace/Contents/Search.js
+++ b/src/renderer/store/TimelineSpace/Contents/Search.js
@@ -1,9 +1,10 @@
 import Account from './Search/Account'
 import Tag from './Search/Tag'
+import Toots from './Search/Toots'
 
 const Search = {
   namespaced: true,
-  modules: { Account, Tag },
+  modules: { Account, Tag, Toots },
   state: {
     loading: false
   },

--- a/src/renderer/store/TimelineSpace/Contents/Search/Toots.js
+++ b/src/renderer/store/TimelineSpace/Contents/Search/Toots.js
@@ -1,0 +1,32 @@
+import Mastodon from 'megalodon'
+
+const Toots = {
+  namespaced: true,
+  state: {
+    results: []
+  },
+  mutations: {
+    updateResults (state, results) {
+      state.results = results
+    }
+  },
+  actions: {
+    search ({ state, commit, rootState }, query) {
+      commit('TimelineSpace/Contents/Search/changeLoading', true, { root: true })
+      const client = new Mastodon(
+        rootState.TimelineSpace.account.accessToken,
+        rootState.TimelineSpace.account.baseURL + '/api/v1'
+      )
+      return client.get('/search', { q: query, resolve: true })
+        .then(res => {
+          commit('updateResults', res.data.statuses)
+          return res.data
+        })
+        .finally(() => {
+          commit('TimelineSpace/Contents/Search/changeLoading', false, { root: true })
+        })
+    }
+  }
+}
+
+export default Toots


### PR DESCRIPTION
This pull request enables searching by toot link within Whalebird.
It does *not* implement loading toots in sidebar by clicking on their links. This is still considered by Whalebird as clicking on an account.