### PR TITLE
Keep an error listener after stopping socket

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -447,7 +447,7 @@ ipcMain.on('start-directmessages-streaming', (event, ac) => {
       directMessagesStreaming = new StreamingManager(account)
       directMessagesStreaming.start(
         'direct',
-        null,
+        '',
         (update) => {
           event.sender.send('update-start-directmessages-streaming', update)
         },
@@ -484,7 +484,7 @@ ipcMain.on('start-local-streaming', (event, ac) => {
       localStreaming = new StreamingManager(account)
       localStreaming.start(
         'public/local',
-        null,
+        '',
         (update) => {
           event.sender.send('update-start-local-streaming', update)
         },
@@ -521,7 +521,7 @@ ipcMain.on('start-public-streaming', (event, ac) => {
       publicStreaming = new StreamingManager(account)
       publicStreaming.start(
         'public',
-        null,
+        '',
         (update) => {
           event.sender.send('update-start-public-streaming', update)
         },

--- a/src/main/streaming.js
+++ b/src/main/streaming.js
@@ -56,6 +56,14 @@ export default class Streaming {
 
   stop () {
     if (this.listener) {
+      this.listener.removeAllListeners('connect')
+      this.listener.removeAllListeners('update')
+      this.listener.removeAllListeners('notification')
+      this.listener.removeAllListeners('error')
+      this.listener.removeAllListeners('parser-error')
+      this.listener.on('error', (e) => {
+        log.error(e)
+      })
       this.listener.stop()
       log.info('streaming stopped')
     }

--- a/src/main/websocket.js
+++ b/src/main/websocket.js
@@ -67,12 +67,15 @@ export default class WebSocket {
 
   stop () {
     if (this.listener) {
-      this.listener.stop()
       this.listener.removeAllListeners('connect')
       this.listener.removeAllListeners('update')
       this.listener.removeAllListeners('notification')
       this.listener.removeAllListeners('error')
       this.listener.removeAllListeners('parser-error')
+      this.listener.on('error', (e) => {
+        log.error(e)
+      })
+      this.listener.stop()
       log.info('streaming stopped')
     }
   }


### PR DESCRIPTION
This prevents the following issues:
 - Leaking error events after stopping a socket.
 - Receiving stray events after switching accounts, if the old socket reconnected after stopping. (This is triggered only when using HTTP streaming, and was already reported in Megalodon.)

Fixes #553.