### PR TITLE
Improve searching accounts with Pleroma/MastoFE

### DIFF
--- a/src/renderer/store/TimelineSpace/Contents/SideBar/AccountProfile.js
+++ b/src/renderer/store/TimelineSpace/Contents/SideBar/AccountProfile.js
@@ -40,12 +40,16 @@ const AccountProfile = {
         rootState.TimelineSpace.account.accessToken,
         rootState.TimelineSpace.account.baseURL + '/api/v1'
       )
-      return client.get('/search', { q: parsedAccount.acct, resolve: true })
+      return client.get('/search', { q: parsedAccount.url, resolve: true })
         .then(res => {
           if (res.data.accounts.length <= 0) throw new AccountNotFound('empty result')
           const account = res.data.accounts.find(a => `@${a.acct}` === parsedAccount.acct)
           if (account) return account
-          const user = res.data.accounts.find(a => `@${a.username}@${rootState.TimelineSpace.account.domain}` === parsedAccount.acct)
+          const pleromaUser = res.data.accounts.find(a => a.acct === parsedAccount.acct)
+          if (pleromaUser) return pleromaUser
+          const localUser = res.data.accounts.find(a => `@${a.username}@${rootState.TimelineSpace.account.domain}` === parsedAccount.acct)
+          if (localUser) return localUser
+          const user = res.data.accounts.find(a => a.url === parsedAccount.url)
           if (!user) throw new AccountNotFound('not found')
           return user
         })

--- a/src/renderer/utils/tootParser.js
+++ b/src/renderer/utils/tootParser.js
@@ -76,8 +76,8 @@ export function parsePleromaAccount (accountURL) {
   const domainName = res[1]
   const accountName = res[2]
   return {
-    username: accountName,
-    acct: `${accountName}@${domainName}`,
+    username: `@${accountName}`,
+    acct: `@${accountName}@${domainName}`,
     url: accountURL
   }
 }

--- a/src/renderer/utils/tootParser.js
+++ b/src/renderer/utils/tootParser.js
@@ -36,7 +36,11 @@ export function parseTag (tagURL) {
 
 export function findAccount (target, parentClass = 'toot') {
   if (target.getAttribute('class') && target.getAttribute('class').includes('u-url')) {
-    return parseMastodonAccount(target.href)
+    if (target.href && target.href.match(/^https:\/\/[a-zA-Z0-9-.]+\/users\/[a-zA-Z0-9-_.]+/)) {
+      return parsePleromaAccount(target.href)
+    } else {
+      return parseMastodonAccount(target.href)
+    }
   }
   // In Pleroma, link does not have class.
   // So we have to check URL.
@@ -62,7 +66,8 @@ export function parseMastodonAccount (accountURL) {
   const accountName = res[2]
   return {
     username: accountName,
-    acct: `${accountName}@${domainName}`
+    acct: `${accountName}@${domainName}`,
+    url: accountURL
   }
 }
 
@@ -71,7 +76,8 @@ export function parsePleromaAccount (accountURL) {
   const domainName = res[1]
   const accountName = res[2]
   return {
-    username: `@${accountName}`,
-    acct: `@${accountName}@${domainName}`
+    username: accountName,
+    acct: `${accountName}@${domainName}`,
+    url: accountURL
   }
 }


### PR DESCRIPTION
I've been testing Pleroma in the last couple of days, and Whalebird's search functionality does not work reliably with it.
First, the canonical URL of Pleroma users is of the form `https://domain.tld/users/username`, which is not expected by Whalebird. 
Pleroma's MastoFE API also doesn't work as expected: the most reliable way to find an account is to query it with the user's canonical URL, and then filter the results by either:
 - `username@domain.tld` (remote accounts)
 - by testing the canonical URL of each result (local accounts do not include the domain in their `acct` field).

I've tested these changes in mastodon.social and pleroma.site and they work as expected.