### PR TITLE
Close sidebar before changing account

### DIFF
--- a/src/renderer/components/TimelineSpace.vue
+++ b/src/renderer/components/TimelineSpace.vue
@@ -51,6 +51,7 @@ export default {
     }
   },
   async created () {
+    this.$store.dispatch('TimelineSpace/Contents/SideBar/close')
     this.$store.commit('TimelineSpace/changeLoading', true)
     await this.initialize()
       .finally(() => {


### PR DESCRIPTION
If the sidebar is open while changing accounts, Whalebird will throw an error about retrieving toot detail/account profile/timeline. This is because, in between changes, the API endpoint points to localhost, and this triggers a redraw of the Vue components.
This pull request prevents this issue by previously closing the sidebar.