### PR TITLE
Prevent multiple toot submissions

### DIFF
--- a/src/renderer/store/TimelineSpace/Modals/NewToot.js
+++ b/src/renderer/store/TimelineSpace/Modals/NewToot.js
@@ -95,6 +95,10 @@ const NewToot = {
       if (rootState.TimelineSpace.account.accessToken === undefined || rootState.TimelineSpace.account.accessToken === null) {
         throw new AuthenticationError()
       }
+      if (state.blockSubmit) {
+        return
+      }
+      commit('changeBlockSubmit', true)
       const client = new Mastodon(
         rootState.TimelineSpace.account.accessToken,
         rootState.TimelineSpace.account.baseURL + '/api/v1'
@@ -102,7 +106,12 @@ const NewToot = {
       return client.post('/statuses', form)
         .then(res => {
           ipcRenderer.send('toot-action-sound')
+          commit('changeBlockSubmit', false)
           return res.data
+        })
+        .catch(e => {
+          commit('changeBlockSubmit', false)
+          throw e
         })
     },
     openReply ({ dispatch, commit, rootState }, message) {

--- a/src/renderer/store/TimelineSpace/Modals/NewToot.js
+++ b/src/renderer/store/TimelineSpace/Modals/NewToot.js
@@ -106,12 +106,10 @@ const NewToot = {
       return client.post('/statuses', form)
         .then(res => {
           ipcRenderer.send('toot-action-sound')
-          commit('changeBlockSubmit', false)
           return res.data
         })
-        .catch(e => {
+        .finally(() => {
           commit('changeBlockSubmit', false)
-          throw e
         })
     },
     openReply ({ dispatch, commit, rootState }, message) {


### PR DESCRIPTION
This pull request prevents multiple concurrent toot posts (e.g. by clicking multiple times the "Toot" button or using the button *and* Ctrl-Enter) by employing the `blockSubmit` state flag.