### PR TITLE
Rescue parser error after streaming listener is closed

### DIFF
--- a/src/main/streaming.js
+++ b/src/main/streaming.js
@@ -64,6 +64,9 @@ export default class Streaming {
       this.listener.on('error', (e) => {
         log.error(e)
       })
+      this.listener.on('parser-error', (e) => {
+        log.error(e)
+      })
       this.listener.stop()
       log.info('streaming stopped')
     }

--- a/src/main/websocket.js
+++ b/src/main/websocket.js
@@ -75,6 +75,9 @@ export default class WebSocket {
       this.listener.on('error', (e) => {
         log.error(e)
       })
+      this.listener.on('parser-error', (e) => {
+        log.error(e)
+      })
       this.listener.stop()
       log.info('streaming stopped')
     }


### PR DESCRIPTION
## Description
When I close (not Quit) Whalebird  in macOS, it is crash.
It only occurs when I use Pleroma instance, because it uses Websocket. The response parser in Websocket listener says an error after close the application.

## Related Issues
Nothing.

## Appearance
No.
