### PR TITLE
Fix package.json for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,10 @@
       "icon": "build/icons/icon.ico",
       "target": "nsis"
     },
+    "nsis": {
+      "oneClick": false,
+      "allowToChangeInstallationDirectory": true
+    },
     "linux": {
       "icon": "build/icons",
       "target": [


### PR DESCRIPTION
## Description
To change the directory which it will be installed for Windows.

## Appearance
Like this when TheDesk's installer made by electron-builder in Japanese.
![image](https://user-images.githubusercontent.com/17561618/53819839-0c9d3700-3fae-11e9-9496-25eb39469af8.png)
