### PR TITLE
fix: Hide long username and instance name in side menu

### DIFF
--- a/src/renderer/components/TimelineSpace/SideMenu.vue
+++ b/src/renderer/components/TimelineSpace/SideMenu.vue
@@ -6,7 +6,7 @@
           <div class="avatar" v-if="collapse">
             <img :src="account.avatar" />
           </div>
-          <div v-else>
+          <div class="acct" v-else>
             @{{ account.username }}
             <span class="domain-name">{{ account.domain }}</span>
           </div>
@@ -201,6 +201,12 @@ export default {
       display: flex;
       align-items: center;
       justify-content: center;
+
+      .acct {
+        max-width: 117px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
 
       .el-dropdown-link {
         cursor: pointer;


### PR DESCRIPTION
## Description
<!-- Please write description. For example, why you change this? -->

## Related Issues
No

## Appearance
![Screenshot from 2019-03-20 22-41-17](https://user-images.githubusercontent.com/4631959/54688623-50bd3980-4b61-11e9-883f-efda01119809.png)
