### PR TITLE
Use accounts/search API instead of v2/search

### DIFF
--- a/src/renderer/store/TimelineSpace/Contents/Search/Account.ts
+++ b/src/renderer/store/TimelineSpace/Contents/Search/Account.ts
@@ -1,4 +1,4 @@
-import Mastodon, { Account, Results } from 'megalodon'
+import Mastodon, { Account } from 'megalodon'
 import { Module, MutationTree, ActionTree } from 'vuex'
 import { RootState } from '@/store'
 
@@ -23,14 +23,12 @@ const mutations: MutationTree<AccountState> = {
 const actions: ActionTree<AccountState, RootState> = {
   search: async ({ commit, rootState }, query: string): Promise<Array<Account>> => {
     commit('TimelineSpace/Contents/Search/changeLoading', true, { root: true })
-    const client = new Mastodon(
-      rootState.TimelineSpace.account.accessToken!,
-      rootState.TimelineSpace.account.baseURL + '/api/v1'
-    )
-    return client.get<Results>('/search', { q: query, resolve: true })
+    const client = new Mastodon(rootState.TimelineSpace.account.accessToken!, rootState.TimelineSpace.account.baseURL + '/api/v1')
+    return client
+      .get<Array<Account>>('/accounts/search', { q: query, resolve: true })
       .then(res => {
-        commit(MUTATION_TYPES.UPDATE_RESULTS, res.data.accounts)
-        return res.data.accounts
+        commit(MUTATION_TYPES.UPDATE_RESULTS, res.data)
+        return res.data
       })
       .finally(() => {
         commit('TimelineSpace/Contents/Search/changeLoading', false, { root: true })

--- a/src/renderer/store/TimelineSpace/Contents/SideBar/AccountProfile.ts
+++ b/src/renderer/store/TimelineSpace/Contents/SideBar/AccountProfile.ts
@@ -1,4 +1,4 @@
-import Mastodon, { Account, Relationship, Response, Results } from 'megalodon'
+import Mastodon, { Account, Relationship, Response } from 'megalodon'
 import Timeline, { TimelineState } from './AccountProfile/Timeline'
 import Follows, { FollowsState } from './AccountProfile/Follows'
 import Followers, { FollowersState } from './AccountProfile/Followers'
@@ -6,14 +6,14 @@ import { Module, MutationTree, ActionTree } from 'vuex'
 import { RootState } from '@/store'
 
 export interface AccountProfileState {
-  account: Account | null,
-  relationship: Relationship | null,
+  account: Account | null
+  relationship: Relationship | null
   loading: boolean
 }
 
 export interface AccountProfileModuleState extends AccountProfileState {
-  Followers: FollowersState,
-  Follows: FollowsState,
+  Followers: FollowersState
+  Follows: FollowsState
   Timeline: TimelineState
 }
 
@@ -43,27 +43,21 @@ const mutations: MutationTree<AccountProfileState> = {
 
 const actions: ActionTree<AccountProfileState, RootState> = {
   fetchAccount: async ({ rootState }, accountID: number): Promise<Account> => {
-    const client = new Mastodon(
-      rootState.TimelineSpace.account.accessToken!,
-      rootState.TimelineSpace.account.baseURL + '/api/v1'
-    )
+    const client = new Mastodon(rootState.TimelineSpace.account.accessToken!, rootState.TimelineSpace.account.baseURL + '/api/v1')
     const res: Response<Account> = await client.get<Account>(`/accounts/${accountID}`)
     return res.data
   },
   searchAccount: async ({ rootState }, parsedAccount): Promise<Account> => {
-    const client = new Mastodon(
-      rootState.TimelineSpace.account.accessToken!,
-      rootState.TimelineSpace.account.baseURL + '/api/v1'
-    )
-    const res: Response<Results> = await client.get<Results>('/search', { q: parsedAccount.url, resolve: true })
-    if (res.data.accounts.length <= 0) throw new AccountNotFound('empty result')
-    const account = res.data.accounts.find(a => `@${a.acct}` === parsedAccount.acct)
+    const client = new Mastodon(rootState.TimelineSpace.account.accessToken!, rootState.TimelineSpace.account.baseURL + '/api/v1')
+    const res: Response<Array<Account>> = await client.get<Array<Account>>('/accounts/search', { q: parsedAccount.url, resolve: true })
+    if (res.data.length <= 0) throw new AccountNotFound('empty result')
+    const account = res.data.find(a => `@${a.acct}` === parsedAccount.acct)
     if (account) return account
-    const pleromaUser = res.data.accounts.find(a => a.acct === parsedAccount.acct)
+    const pleromaUser = res.data.find(a => a.acct === parsedAccount.acct)
     if (pleromaUser) return pleromaUser
-    const localUser = res.data.accounts.find(a => `@${a.username}@${rootState.TimelineSpace.account.domain}` === parsedAccount.acct)
+    const localUser = res.data.find(a => `@${a.username}@${rootState.TimelineSpace.account.domain}` === parsedAccount.acct)
     if (localUser) return localUser
-    const user = res.data.accounts.find(a => a.url === parsedAccount.url)
+    const user = res.data.find(a => a.url === parsedAccount.url)
     if (!user) throw new AccountNotFound('not found')
     return user
   },
@@ -73,28 +67,19 @@ const actions: ActionTree<AccountProfileState, RootState> = {
   },
   fetchRelationship: async ({ commit, rootState }, account: Account): Promise<Relationship> => {
     commit(MUTATION_TYPES.CHANGE_RELATIONSHIP, null)
-    const client = new Mastodon(
-      rootState.TimelineSpace.account.accessToken!,
-      rootState.TimelineSpace.account.baseURL + '/api/v1'
-    )
+    const client = new Mastodon(rootState.TimelineSpace.account.accessToken!, rootState.TimelineSpace.account.baseURL + '/api/v1')
     const res: Response<Relationship> = await client.get<Relationship>('/accounts/relationships', { id: [account.id] })
     commit(MUTATION_TYPES.CHANGE_RELATIONSHIP, res.data[0])
     return res.data
   },
   follow: async ({ commit, rootState }, account: Account) => {
-    const client = new Mastodon(
-      rootState.TimelineSpace.account.accessToken!,
-      rootState.TimelineSpace.account.baseURL + '/api/v1'
-    )
+    const client = new Mastodon(rootState.TimelineSpace.account.accessToken!, rootState.TimelineSpace.account.baseURL + '/api/v1')
     const res: Response<Relationship> = await client.post<Relationship>(`/accounts/${account.id}/follow`)
     commit(MUTATION_TYPES.CHANGE_RELATIONSHIP, res.data)
     return res.data
   },
   unfollow: async ({ commit, rootState }, account: Account) => {
-    const client = new Mastodon(
-      rootState.TimelineSpace.account.accessToken!,
-      rootState.TimelineSpace.account.baseURL + '/api/v1'
-    )
+    const client = new Mastodon(rootState.TimelineSpace.account.accessToken!, rootState.TimelineSpace.account.baseURL + '/api/v1')
     const res: Response<Relationship> = await client.post<Relationship>(`/accounts/${account.id}/unfollow`)
     commit(MUTATION_TYPES.CHANGE_RELATIONSHIP, res.data)
     return res.data
@@ -103,28 +88,19 @@ const actions: ActionTree<AccountProfileState, RootState> = {
     commit(MUTATION_TYPES.CHANGE_ACCOUNT, null)
   },
   unmute: async ({ rootState, commit }, account: Account) => {
-    const client = new Mastodon(
-      rootState.TimelineSpace.account.accessToken!,
-      rootState.TimelineSpace.account.baseURL + '/api/v1'
-    )
+    const client = new Mastodon(rootState.TimelineSpace.account.accessToken!, rootState.TimelineSpace.account.baseURL + '/api/v1')
     const res: Response<Relationship> = await client.post<Relationship>(`/accounts/${account.id}/unmute`)
     commit(MUTATION_TYPES.CHANGE_RELATIONSHIP, res.data)
     return res.data
   },
   block: async ({ rootState, commit }, account: Account) => {
-    const client = new Mastodon(
-      rootState.TimelineSpace.account.accessToken!,
-      rootState.TimelineSpace.account.baseURL + '/api/v1'
-    )
+    const client = new Mastodon(rootState.TimelineSpace.account.accessToken!, rootState.TimelineSpace.account.baseURL + '/api/v1')
     const res: Response<Relationship> = await client.post<Relationship>(`/accounts/${account.id}/block`)
     commit(MUTATION_TYPES.CHANGE_RELATIONSHIP, res.data)
     return res.data
   },
   unblock: async ({ rootState, commit }, account: Account) => {
-    const client = new Mastodon(
-      rootState.TimelineSpace.account.accessToken!,
-      rootState.TimelineSpace.account.baseURL + '/api/v1'
-    )
+    const client = new Mastodon(rootState.TimelineSpace.account.accessToken!, rootState.TimelineSpace.account.baseURL + '/api/v1')
     const res: Response<Relationship> = await client.post<Relationship>(`/accounts/${account.id}/unblock`)
     commit(MUTATION_TYPES.CHANGE_RELATIONSHIP, res.data)
     return res.data


### PR DESCRIPTION
## Description
`v2/search` API returns account, tag and toot when search. But we don't need tag and toot when search accounts.

## Related Issues
No.

## Appearance
<!-- If you change the appearance, please paste the screen shots. -->
