### PR TITLE
closes #893 Remove commas between pinned hashtags in new toot

### DIFF
--- a/src/renderer/store/TimelineSpace/Modals/NewToot.ts
+++ b/src/renderer/store/TimelineSpace/Modals/NewToot.ts
@@ -170,7 +170,7 @@ const actions: ActionTree<NewTootState, RootState> = {
   },
   openModal: ({ dispatch, commit, state }) => {
     if (!state.replyToMessage && state.pinedHashtag) {
-      commit(MUTATION_TYPES.UPDATE_INITIAL_STATUS, state.hashtags.map(t => ` #${t.name}`).join())
+      commit(MUTATION_TYPES.UPDATE_INITIAL_STATUS, state.hashtags.map(t => `#${t.name}`).join(' '))
     }
     commit(MUTATION_TYPES.CHANGE_MODAL, true)
     dispatch('fetchVisibility')


### PR DESCRIPTION
## Description
`Array.join` use `,` as default, so I change the argument.

## Related Issues
ref: #893 
## Appearance
<!-- If you change the appearance, please paste the screen shots. -->
