### PR TITLE
closes #956 Stop user streaming after remove account association

### DIFF
--- a/src/main/account.ts
+++ b/src/main/account.ts
@@ -175,16 +175,16 @@ export default class Account {
     })
   }
 
-  removeAccount(id: string): Promise<number> {
+  removeAccount(id: string): Promise<string> {
     return new Promise((resolve, reject) => {
       this.db.remove(
         {
           _id: id
         },
         { multi: true },
-        (err, numRemoved) => {
+        (err, _numRemoved) => {
           if (err) return reject(err)
-          resolve(numRemoved)
+          resolve(id)
         }
       )
     })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -363,8 +363,9 @@ ipcMain.on('update-account', (event: Event, acct: LocalAccount) => {
 ipcMain.on('remove-account', (event: Event, id: string) => {
   accountManager
     .removeAccount(id)
-    .then(() => {
-      event.sender.send('response-remove-account')
+    .then((id) => {
+      stopUserStreaming(id)
+      event.sender.send('response-remove-account', id)
     })
     .catch(err => {
       event.sender.send('error-remove-account', err)
@@ -492,6 +493,19 @@ ipcMain.on('stop-all-user-streamings', () => {
     }
   })
 })
+
+/**
+ * Stop an user streaming in all user streamings.
+ * @param id specified user id in nedb.
+ */
+const stopUserStreaming = (id: string) => {
+  Object.keys(userStreamings).map((key: string) => {
+    if (key === id && userStreamings[id]) {
+      userStreamings[id]!.stop()
+      userStreamings[id] = null
+    }
+  })
+}
 
 type StreamingSetting = {
   account: LocalAccount

--- a/src/renderer/store/Preferences/Account.ts
+++ b/src/renderer/store/Preferences/Account.ts
@@ -49,7 +49,7 @@ const actions: ActionTree<AccountState, RootState> = {
         ipcRenderer.removeAllListeners('response-remove-account')
         reject(err)
       })
-      ipcRenderer.once('response-remove-account', () => {
+      ipcRenderer.once('response-remove-account', (_id: string) => {
         ipcRenderer.removeAllListeners('error-remove-account')
         resolve()
       })


### PR DESCRIPTION
## Description
Now Whalebird runs all user streamings, so when user remove account association we have to stop the user streaming.

## Related Issues
ref: #956 

## Appearance
<!-- If you change the appearance, please paste the screen shots. -->
