### PR TITLE
closes #958 Notify notification in main process

### DIFF
--- a/src/config/locales/de/translation.missing.json
+++ b/src/config/locales/de/translation.missing.json
@@ -97,5 +97,19 @@
     "new_toot": {
       "poll_invalid": "Invalid poll choices"
     }
+  },
+  "notification": {
+    "favourite": {
+      "title": "Favourite",
+      "body": "{{username}} favourited your status"
+    },
+    "follow": {
+      "title": "Follow",
+      "body": "{{username}} is now following you"
+    },
+    "reblog": {
+      "title": "Reblog",
+      "body": "{{username}} boosted your status"
+    }
   }
 }

--- a/src/config/locales/en/translation.json
+++ b/src/config/locales/en/translation.json
@@ -409,5 +409,19 @@
       "attach_image": "You can only attach images or videos",
       "poll_invalid": "Invalid poll choices"
     }
+  },
+  "notification": {
+    "favourite": {
+      "title": "Favourite",
+      "body": "{{username}} favourited your status"
+    },
+    "follow": {
+      "title": "Follow",
+      "body": "{{username}} is now following you"
+    },
+    "reblog": {
+      "title": "Reblog",
+      "body": "{{username}} boosted your status"
+    }
   }
 }

--- a/src/config/locales/fr/translation.missing.json
+++ b/src/config/locales/fr/translation.missing.json
@@ -64,5 +64,19 @@
     "new_toot": {
       "poll_invalid": "Invalid poll choices"
     }
+  },
+  "notification": {
+    "favourite": {
+      "title": "Favourite",
+      "body": "{{username}} favourited your status"
+    },
+    "follow": {
+      "title": "Follow",
+      "body": "{{username}} is now following you"
+    },
+    "reblog": {
+      "title": "Reblog",
+      "body": "{{username}} boosted your status"
+    }
   }
 }

--- a/src/config/locales/it/translation.missing.json
+++ b/src/config/locales/it/translation.missing.json
@@ -53,5 +53,19 @@
     "new_toot": {
       "poll_invalid": "Invalid poll choices"
     }
+  },
+  "notification": {
+    "favourite": {
+      "title": "Favourite",
+      "body": "{{username}} favourited your status"
+    },
+    "follow": {
+      "title": "Follow",
+      "body": "{{username}} is now following you"
+    },
+    "reblog": {
+      "title": "Reblog",
+      "body": "{{username}} boosted your status"
+    }
   }
 }

--- a/src/config/locales/ja/translation.json
+++ b/src/config/locales/ja/translation.json
@@ -409,5 +409,19 @@
       "attach_image": "画像かビデオしか添付できません",
       "poll_invalid": "アンケートに不正な選択肢が含まれています"
     }
+  },
+  "notification": {
+    "favourite": {
+      "title": "お気に入り",
+      "body": "{{username}} さんにお気に入り登録されました"
+    },
+    "follow": {
+      "title": "フォロー",
+      "body": "{{username}} さんにフォローされました"
+    },
+    "reblog": {
+      "title": "ブースト",
+      "body": "{{username}} さんにブーストされました"
+    }
   }
 }

--- a/src/config/locales/ko/translation.missing.json
+++ b/src/config/locales/ko/translation.missing.json
@@ -73,5 +73,19 @@
     "new_toot": {
       "poll_invalid": "Invalid poll choices"
     }
+  },
+  "notification": {
+    "favourite": {
+      "title": "Favourite",
+      "body": "{{username}} favourited your status"
+    },
+    "follow": {
+      "title": "Follow",
+      "body": "{{username}} is now following you"
+    },
+    "reblog": {
+      "title": "Reblog",
+      "body": "{{username}} boosted your status"
+    }
   }
 }

--- a/src/config/locales/pl/translation.missing.json
+++ b/src/config/locales/pl/translation.missing.json
@@ -97,5 +97,19 @@
     "new_toot": {
       "poll_invalid": "Invalid poll choices"
     }
+  },
+  "notification": {
+    "favourite": {
+      "title": "Favourite",
+      "body": "{{username}} favourited your status"
+    },
+    "follow": {
+      "title": "Follow",
+      "body": "{{username}} is now following you"
+    },
+    "reblog": {
+      "title": "Reblog",
+      "body": "{{username}} boosted your status"
+    }
   }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -39,6 +39,7 @@ import { LocalTag } from '~/src/types/localTag'
 import { UnreadNotification as UnreadNotificationConfig } from '~/src/types/unreadNotification'
 import { Notify } from '~/src/types/notify'
 import { StreamingError } from '~/src/errors/streamingError'
+import i18next from '~/src/config/i18n'
 
 /**
  * Context menu
@@ -1152,8 +1153,8 @@ const createNotification = (notification: RemoteNotification, notifyConfig: Noti
     case 'favourite':
       if (notifyConfig.favourite) {
         return {
-          title: 'Favourite',
-          body: `${username(notification.account)} favourited your status`,
+          title: i18next.t('notification.favourite.title'),
+          body: i18next.t('notification.favourite.body', { username: username(notification.account) }),
           silent: false
         } as NotificationConstructorOptions
       }
@@ -1161,8 +1162,8 @@ const createNotification = (notification: RemoteNotification, notifyConfig: Noti
     case 'follow':
       if (notifyConfig.follow) {
         return {
-          title: 'Follow',
-          body: `${username(notification.account)} is now following you`,
+          title: i18next.t('notification.follow.title'),
+          body: i18next.t('notification.follow.body', { username: username(notification.account) }),
           silent: false
         } as NotificationConstructorOptions
       }
@@ -1182,8 +1183,8 @@ const createNotification = (notification: RemoteNotification, notifyConfig: Noti
     case 'reblog':
       if (notifyConfig.reblog) {
         return {
-          title: 'Reblog',
-          body: `${username(notification.account)} boosted your status`,
+          title: i18next.t('notification.reblog.title'),
+          body: i18next.t('notification.reblog.body', { username: username(notification.account) }),
           silent: false
         } as NotificationConstructorOptions
       }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -32,14 +32,13 @@ import Preferences from './preferences'
 import Fonts from './fonts'
 import Hashtags from './hashtags'
 import UnreadNotification from './unreadNotification'
-import i18n from '../config/i18n'
+import i18n from '~/src/config/i18n'
 import Language from '../constants/language'
 import { LocalAccount } from '~/src/types/localAccount'
 import { LocalTag } from '~/src/types/localTag'
 import { UnreadNotification as UnreadNotificationConfig } from '~/src/types/unreadNotification'
 import { Notify } from '~/src/types/notify'
 import { StreamingError } from '~/src/errors/streamingError'
-import i18next from '~/src/config/i18n'
 
 /**
  * Context menu
@@ -1153,8 +1152,8 @@ const createNotification = (notification: RemoteNotification, notifyConfig: Noti
     case 'favourite':
       if (notifyConfig.favourite) {
         return {
-          title: i18next.t('notification.favourite.title'),
-          body: i18next.t('notification.favourite.body', { username: username(notification.account) }),
+          title: i18n.t('notification.favourite.title'),
+          body: i18n.t('notification.favourite.body', { username: username(notification.account) }),
           silent: false
         } as NotificationConstructorOptions
       }
@@ -1162,8 +1161,8 @@ const createNotification = (notification: RemoteNotification, notifyConfig: Noti
     case 'follow':
       if (notifyConfig.follow) {
         return {
-          title: i18next.t('notification.follow.title'),
-          body: i18next.t('notification.follow.body', { username: username(notification.account) }),
+          title: i18n.t('notification.follow.title'),
+          body: i18n.t('notification.follow.body', { username: username(notification.account) }),
           silent: false
         } as NotificationConstructorOptions
       }
@@ -1183,8 +1182,8 @@ const createNotification = (notification: RemoteNotification, notifyConfig: Noti
     case 'reblog':
       if (notifyConfig.reblog) {
         return {
-          title: i18next.t('notification.reblog.title'),
-          body: i18next.t('notification.reblog.body', { username: username(notification.account) }),
+          title: i18n.t('notification.reblog.title'),
+          body: i18n.t('notification.reblog.body', { username: username(notification.account) }),
           silent: false
         } as NotificationConstructorOptions
       }

--- a/src/renderer/components/GlobalHeader.vue
+++ b/src/renderer/components/GlobalHeader.vue
@@ -56,9 +56,6 @@ export default {
   created() {
     this.initialize()
   },
-  destroyed() {
-    this.$store.dispatch('GlobalHeader/unbindUserStreamings')
-  },
   methods: {
     activeRoute() {
       return this.$route.path


### PR DESCRIPTION
## Description
Use [Notification class](https://electronjs.org/docs/api/notification) in main process to notify all notifications.
Now Whalebird notify it in renderer process, but notifications can not be received when user open preferences, and minimize to tray.

I want to receive notification always, so notify notifications in main process.

- [x] Move notification logic to main process
- [x] Use translations in notification

## Related Issues
ref: #958 

## Appearance
<!-- If you change the appearance, please paste the screen shots. -->
