### PR TITLE
refs #975 fix: Check webContents status when receive status in streaming

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -445,7 +445,9 @@ ipcMain.on('start-all-user-streamings', (event: Event, accounts: Array<LocalAcco
         userStreamings[id] = new StreamingManager(acct, true)
         userStreamings[id]!.startUser(
           (update: Status) => {
-            event.sender.send(`update-start-all-user-streamings-${id}`, update)
+            if (!event.sender.isDestroyed()) {
+              event.sender.send(`update-start-all-user-streamings-${id}`, update)
+            }
           },
           (notification: RemoteNotification) => {
             const preferences = new Preferences(preferencesDBPath)


### PR DESCRIPTION
## Description
This fix was leaking in #978.

## Related Issues
ref: #975 
## Appearance
<!-- If you change the appearance, please paste the screen shots. -->
