### PR TITLE
closes #1012 Enable nodeIntegration in about window

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2548,9 +2548,9 @@
       "dev": true
     },
     "about-window": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/about-window/-/about-window-1.12.1.tgz",
-      "integrity": "sha512-P/fJACq7RBFpv5Ql0kIqpOYgFqQ8WdoZoB7wrKmDvwTSKVOMbUZMYnQYtnOW6dHmMCYuNrmQFf+MxvuhE+KrzQ=="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/about-window/-/about-window-1.13.1.tgz",
+      "integrity": "sha512-1gkTfnpGWh3xmPqrkJoe2Ya7lbIFGXG+/UZ8XAYQiEsnDLjF9nWSZXw5ApBpFRd3hUx0koN5uFd6hhbEB8InJQ=="
     },
     "accepts": {
       "version": "1.3.7",

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
   "dependencies": {
     "@panter/vue-i18next": "^0.13.0",
     "@trodi/electron-splashscreen": "^0.3.4",
-    "about-window": "^1.11.0",
+    "about-window": "^1.13.1",
     "animate.css": "^3.7.0",
     "axios": "^0.18.1",
     "boom": "^7.3.0",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1096,7 +1096,12 @@ const ApplicationMenu = (accountsChange: Array<MenuItemConstructorOptions>, i18n
               icon_path: path.resolve(__dirname, '../../build/icons/256x256.png'),
               copyright: 'Copyright (c) 2018 AkiraFukushima',
               package_json_dir: path.resolve(__dirname, '../../'),
-              open_devtools: process.env.NODE_ENV !== 'production'
+              open_devtools: process.env.NODE_ENV !== 'production',
+              win_options: {
+                webPreferences: {
+                  nodeIntegration: true
+                }
+              }
             })
           }
         },


### PR DESCRIPTION
## Description
Electron v5.x is set nodeIntegration to false as default, so about window could not render.

## Related Issues
refs: #1012 

## Appearance
![Screenshot from 2019-08-24 01-38-48](https://user-images.githubusercontent.com/4631959/63608435-f6dd0600-c60f-11e9-8e62-121e2f30390d.png)

