### PR TITLE
Enforces single instance for linux and windows

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -74,6 +74,25 @@ let mainWindow: BrowserWindow | null
 let tray: Tray | null
 const winURL = process.env.NODE_ENV === 'development' ? `http://localhost:9080` : `file://${__dirname}/index.html`
 
+// Enforces single instance for linux and windows.
+const gotTheLock = app.requestSingleInstanceLock()
+
+if (!gotTheLock) {
+  app.quit()
+} else {
+  app.on('second-instance', () => {
+    // Someone tried to run a second instance, we should focus our window.
+    if (mainWindow) {
+      if (mainWindow.isMinimized()) mainWindow.restore()
+      if (!mainWindow!.isVisible()) {
+        mainWindow!.show()
+        mainWindow!.setSkipTaskbar(false)
+      }
+      mainWindow.focus()
+    }
+  })
+}
+
 const appId = pkg.build.appId
 
 const splashURL =


### PR DESCRIPTION
> On macOS, the system enforces single instance automatically when users try to open a second instance of your app in Finder, and the open-file and open-url events will be emitted for that. However when users start your app in command line, the system's single instance mechanism will be bypassed, and you have to use this method to ensure single instance.

from API Documents
<https://github.com/electron/electron/blob/master/docs/api/app.md#user-content-apprequestsingleinstancelock>

あまり自信がないのでチェックお願いします。
