### PR TITLE
fix: Remove cache file when load error

### DIFF
--- a/src/main/cache/account.ts
+++ b/src/main/cache/account.ts
@@ -1,5 +1,6 @@
 import { isEmpty } from 'lodash'
 import Datastore from 'nedb'
+import fs from 'fs'
 import { CachedAccount } from '~/src/types/cachedAccount'
 
 export default class AccountCache {
@@ -8,7 +9,16 @@ export default class AccountCache {
   constructor(path: string) {
     this.db = new Datastore({
       filename: path,
-      autoload: true
+      autoload: true,
+      onload: (err: Error) => {
+        if (err) {
+          fs.unlink(path, err => {
+            if (err) {
+              console.error(err)
+            }
+          })
+        }
+      }
     })
   }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -482,7 +482,7 @@ ipcMain.on('start-all-user-streamings', (event: Event, accounts: Array<LocalAcco
           }
           // Cache hashtag
           update.tags.map(async tag => {
-            await hashtagCache.insertHashtag(tag.name)
+            await hashtagCache.insertHashtag(tag.name).catch(err => console.error(err))
           })
           // Cache account
           await accountCache.insertAccount(id, update.account.acct).catch(err => console.error(err))
@@ -1021,7 +1021,7 @@ ipcMain.on('get-cache-hashtags', async (event: Event) => {
 
 ipcMain.on('insert-cache-hashtags', (event: Event, tags: Array<string>) => {
   tags.map(async name => {
-    await hashtagCache.insertHashtag(name)
+    await hashtagCache.insertHashtag(name).catch(err => console.error(err))
   })
   event.sender.send('response-insert-cache-hashtags')
 })


### PR DESCRIPTION
## Description
Sometimes invalid cache items are inserted, then can't load cache file in nedb.
So we have to clear cache files when load error has occur.

## Related Issues
<!-- If there are related issues, please write issue number. -->

## Appearance
<!-- If you change the appearance, please paste the screen shots. -->
