### PR TITLE
refs #1028 Confirm ActivityPub instance to read host-meta before login

### DIFF
--- a/spec/renderer/integration/store/Login.spec.ts
+++ b/spec/renderer/integration/store/Login.spec.ts
@@ -42,10 +42,9 @@ describe('Login', () => {
         ipcMain.once('get-auth-url', event => {
           event.sender.send('error-get-auth-url', new Error())
         })
-        await store.dispatch('Login/fetchLogin', 'pleroma.io')
-          .catch((err: Error) => {
-            expect(err instanceof Error).toEqual(true)
-          })
+        await store.dispatch('Login/fetchLogin', 'pleroma.io').catch((err: Error) => {
+          expect(err instanceof Error).toEqual(true)
+        })
       })
     })
     describe('success', () => {
@@ -72,9 +71,10 @@ describe('Login', () => {
       // https://github.com/facebook/jest/issues/6552
       // https://github.com/kulshekhar/ts-jest/issues/828
       const mockedAxios = axios as any
-      const res: Promise<object> = new Promise<object>(resolve => {
+      const res: Promise<{}> = new Promise<{}>(resolve => {
         resolve({
-          data: 'test'
+          data:
+            '<?xml version="1.0" encoding="UTF-8"?><XRD xmlns="http://docs.oasis-open.org/ns/xri/xrd-1.0"><Link rel="lrdd" template="https://pleroma.io/.well-known/webfinger?resource={uri}" type="application/xrd+xml" /></XRD>'
         })
       })
       mockedAxios.get.mockImplementation(() => res)


### PR DESCRIPTION
## Description
Some mastodon instance does not open `/api/v1/instance`, so user can not login these instances using Whalebird.
On other hand, we have to confirm  whether the domain can say activity pub.

## Related Issues
refs: #1028 

## Appearance
<!-- If you change the appearance, please paste the screen shots. -->
