### PR TITLE
refs #901 Use ipcRenderer directly from electron

### DIFF
--- a/spec/renderer/integration/store/App.spec.ts
+++ b/spec/renderer/integration/store/App.spec.ts
@@ -1,6 +1,6 @@
 import { createLocalVue } from '@vue/test-utils'
 import Vuex from 'vuex'
-import { ipcMain, ipcRenderer } from '~/spec/mock/electron'
+import { ipcMain } from '~/spec/mock/electron'
 import App from '@/store/App'
 import DisplayStyle from '~/src/constants/displayStyle'
 import { LightTheme, DarkTheme } from '~/src/constants/themeColor'
@@ -8,7 +8,6 @@ import Theme from '~/src/constants/theme'
 import TimeFormat from '~/src/constants/timeFormat'
 import Language from '~/src/constants/language'
 import DefaultFonts from '@/utils/fonts'
-import { MyWindow } from '~/src/types/global'
 
 const state = () => {
   return {
@@ -44,7 +43,6 @@ describe('App', () => {
   let localVue
 
   beforeEach(() => {
-    ;(<MyWindow>window).ipcRenderer = ipcRenderer
     localVue = createLocalVue()
     localVue.use(Vuex)
     store = new Vuex.Store({

--- a/src/renderer/store/App.ts
+++ b/src/renderer/store/App.ts
@@ -11,9 +11,7 @@ import { Notify } from '~/src/types/notify'
 import { BaseConfig } from '~/src/types/preference'
 import { Appearance } from '~/src/types/appearance'
 import { ProxyConfig } from 'megalodon'
-import { MyWindow } from '~/src/types/global'
-
-const win = window as MyWindow
+import { ipcRenderer } from 'electron'
 
 export type AppState = {
   theme: ThemeColorType
@@ -109,22 +107,22 @@ const mutations: MutationTree<AppState> = {
 
 const actions: ActionTree<AppState, RootState> = {
   watchShortcutsEvents: () => {
-    win.ipcRenderer.on('open-preferences', () => {
+    ipcRenderer.on('open-preferences', () => {
       router.push('/preferences/general')
     })
   },
   removeShortcutsEvents: () => {
-    win.ipcRenderer.removeAllListeners('open-preferences')
+    ipcRenderer.removeAllListeners('open-preferences')
   },
   loadPreferences: ({ commit, dispatch }) => {
     return new Promise((resolve, reject) => {
-      win.ipcRenderer.send('get-preferences')
-      win.ipcRenderer.once('error-get-preferences', (_, err: Error) => {
-        win.ipcRenderer.removeAllListeners('response-get-preferences')
+      ipcRenderer.send('get-preferences')
+      ipcRenderer.once('error-get-preferences', (_, err: Error) => {
+        ipcRenderer.removeAllListeners('response-get-preferences')
         reject(err)
       })
-      win.ipcRenderer.once('response-get-preferences', (_, conf: BaseConfig) => {
-        win.ipcRenderer.removeAllListeners('error-get-preferences')
+      ipcRenderer.once('response-get-preferences', (_, conf: BaseConfig) => {
+        ipcRenderer.removeAllListeners('error-get-preferences')
         dispatch('updateTheme', conf.appearance)
         commit(MUTATION_TYPES.UPDATE_DISPLAY_NAME_STYLE, conf.appearance.displayNameStyle)
         commit(MUTATION_TYPES.UPDATE_FONT_SIZE, conf.appearance.fontSize)
@@ -168,11 +166,11 @@ const actions: ActionTree<AppState, RootState> = {
   },
   loadProxy: ({ commit }) => {
     return new Promise(resolve => {
-      win.ipcRenderer.once('response-get-proxy-configuration', (_, proxy: ProxyConfig | false) => {
+      ipcRenderer.once('response-get-proxy-configuration', (_, proxy: ProxyConfig | false) => {
         commit(MUTATION_TYPES.UPDATE_PROXY_CONFIGURATION, proxy)
         resolve(proxy)
       })
-      win.ipcRenderer.send('get-proxy-configuration')
+      ipcRenderer.send('get-proxy-configuration')
     })
   }
 }


### PR DESCRIPTION
## Description
Now we can't disable nodeIntegration, because megalodon is uging `https-proxy-agent` and `socks-proxy-agent`. There libraries are using node.js core libraries, for example `net`, `dns`, and `tls`. So we can't compile its for web.

## Related Issues
refs: #901 

## Appearance
<!-- If you change the appearance, please paste the screen shots. -->
