### PR TITLE
refs #1163 Use default preference if the file does not exist when get proxy configuration

### DIFF
--- a/src/main/preferences.ts
+++ b/src/main/preferences.ts
@@ -93,9 +93,9 @@ export default class Preferences {
     this.path = path
   }
 
-  async load(): Promise<BaseConfig> {
+  public async load(): Promise<BaseConfig> {
     try {
-      const preferences = await this.get()
+      const preferences = await this._get()
       return objectAssignDeep({}, Base, preferences)
     } catch (err) {
       log.error(err)
@@ -103,7 +103,7 @@ export default class Preferences {
     }
   }
 
-  get(): Promise<BaseConfig> {
+  private _get(): Promise<BaseConfig> {
     return new Promise((resolve, reject) => {
       storage.get(this.path, (err, data) => {
         if (err) return reject(err)
@@ -112,7 +112,7 @@ export default class Preferences {
     })
   }
 
-  save(data: BaseConfig): Promise<BaseConfig> {
+  private _save(data: BaseConfig): Promise<BaseConfig> {
     return new Promise((resolve, reject) => {
       storage.set(this.path, data, err => {
         if (err) return reject(err)
@@ -121,10 +121,10 @@ export default class Preferences {
     })
   }
 
-  async update(obj: any): Promise<BaseConfig> {
+  public async update(obj: any): Promise<BaseConfig> {
     const current = await this.load()
     const data = objectAssignDeep({}, current, obj)
-    const result = await this.save(data)
+    const result = await this._save(data)
     return result
   }
 }

--- a/src/main/proxy.ts
+++ b/src/main/proxy.ts
@@ -44,7 +44,7 @@ export default class ProxyConfiguration {
   }
 
   public async getConfig(): Promise<false | ManualProxy> {
-    const conf = await this.preferences.get()
+    const conf = await this.preferences.load()
     const source = conf.proxy.source as ProxySource
     switch (source) {
       case ProxySource.no:


### PR DESCRIPTION
## Description
If `preference.db` does not exist, unhandled exception is occur. Because `Preferences#get` method return empty object when the file does not exist. So we can not read proxy configuration from preferences.

## Related Issues
refs: #1163 

## Appearance
<!-- If you change the appearance, please paste the screen shots. -->
