### PR TITLE
Build preload script for production

### DIFF
--- a/.electron-vue/webpack.main.config.js
+++ b/.electron-vue/webpack.main.config.js
@@ -11,7 +11,8 @@ const MinifyPlugin = require('babel-minify-webpack-plugin')
 
 let mainConfig = {
   entry: {
-    main: path.join(__dirname, '../src/main/index.ts')
+    main: path.join(__dirname, '../src/main/index.ts'),
+    preload: path.join(__dirname, '../src/main/preload.js')
   },
   externals: [...Object.keys(dependencies || {})],
   module: {


### PR DESCRIPTION
## Description
In production, preload.js can' be loaded because webpack does not output preload.js, it only output main.js. So I add prealod.js as entry.

## Related Issues
<!-- If there are related issues, please write issue number. -->

## Appearance
<!-- If you change the appearance, please paste the screen shots. -->
