### PR TITLE
Remove babel-minify because webpack can minify using terser when production

### DIFF
--- a/.electron-vue/webpack.main.config.js
+++ b/.electron-vue/webpack.main.config.js
@@ -7,7 +7,6 @@ const { dependencies } = require('../package.json')
 const webpack = require('webpack')
 
 const CopyWebpackPlugin = require('copy-webpack-plugin')
-const MinifyPlugin = require('babel-minify-webpack-plugin')
 
 let mainConfig = {
   entry: {
@@ -95,8 +94,8 @@ if (process.env.NODE_ENV !== 'production') {
  * Adjust mainConfig for production settings
  */
 if (process.env.NODE_ENV === 'production') {
+  mainConfig.mode = 'production'
   mainConfig.plugins.push(
-    new MinifyPlugin(),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': '"production"'
     })

--- a/.electron-vue/webpack.renderer.config.js
+++ b/.electron-vue/webpack.renderer.config.js
@@ -6,7 +6,6 @@ const path = require('path')
 const { dependencies } = require('../package.json')
 const webpack = require('webpack')
 
-const MinifyPlugin = require('babel-minify-webpack-plugin')
 const CopyWebpackPlugin = require('copy-webpack-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
@@ -178,9 +177,8 @@ if (process.env.NODE_ENV !== 'production') {
  */
 if (process.env.NODE_ENV === 'production') {
   rendererConfig.devtool = ''
-
+  rendererConfig.mode = 'production'
   rendererConfig.plugins.push(
-    new MinifyPlugin(),
     new CopyWebpackPlugin([
       {
         from: path.join(__dirname, '../static'),

--- a/.electron-vue/webpack.web.config.js
+++ b/.electron-vue/webpack.web.config.js
@@ -5,7 +5,6 @@ process.env.BABEL_ENV = 'web'
 const path = require('path')
 const webpack = require('webpack')
 
-const MinifyPlugin = require('babel-minify-webpack-plugin')
 const CopyWebpackPlugin = require('copy-webpack-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
@@ -52,7 +51,7 @@ let webConfig = {
       {
         test: /\.js$/,
         use: 'babel-loader',
-        include: [ path.resolve(__dirname, '../src/renderer') ],
+        include: [path.resolve(__dirname, '../src/renderer')],
         exclude: /node_modules/
       },
       {
@@ -93,7 +92,7 @@ let webConfig = {
   },
   plugins: [
     new VueLoaderPlugin(),
-    new MiniCssExtractPlugin({filename: 'styles.css'}),
+    new MiniCssExtractPlugin({ filename: 'styles.css' }),
     new HtmlWebpackPlugin({
       filename: 'index.html',
       template: path.resolve(__dirname, '../src/index.ejs'),
@@ -117,7 +116,7 @@ let webConfig = {
   resolve: {
     alias: {
       '@': path.join(__dirname, '../src/renderer'),
-      'vue$': 'vue/dist/vue.esm.js'
+      vue$: 'vue/dist/vue.esm.js'
     },
     extensions: ['.js', '.vue', '.json', '.css']
   },
@@ -129,9 +128,8 @@ let webConfig = {
  */
 if (process.env.NODE_ENV === 'production') {
   webConfig.devtool = ''
-
+  webConfig.mode = 'production'
   webConfig.plugins.push(
-    new MinifyPlugin(),
     new CopyWebpackPlugin([
       {
         from: path.join(__dirname, '../static'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -4806,12 +4806,6 @@
         "lodash": "^4.17.4"
       }
     },
-    "babel-helper-evaluate-path": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.3.0.tgz",
-      "integrity": "sha512-dRFlMTqUJRGzx5a2smKxmptDdNCXKSkPcXWzKLwAV72hvIZumrd/0z9RcewHkr7PmAEq+ETtpD1GK6wZ6ZUXzw==",
-      "dev": true
-    },
     "babel-helper-explode-assignable-expression": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
@@ -4822,12 +4816,6 @@
         "babel-traverse": "^6.24.1",
         "babel-types": "^6.24.1"
       }
-    },
-    "babel-helper-flip-expressions": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.3.0.tgz",
-      "integrity": "sha512-kNGohWmtAG3b7tN1xocRQ5rsKkH/hpvZsMiGOJ1VwGJKhnwzR5KlB3rvKBaBPl5/IGHcopB2JN+r1SUEX1iMAw==",
-      "dev": true
     },
     "babel-helper-function-name": {
       "version": "6.24.1",
@@ -4861,24 +4849,6 @@
         "babel-runtime": "^6.22.0",
         "babel-types": "^6.24.1"
       }
-    },
-    "babel-helper-is-nodes-equiv": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
-      "integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ=",
-      "dev": true
-    },
-    "babel-helper-is-void-0": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.3.0.tgz",
-      "integrity": "sha512-JVqdX8y7Rf/x4NwbqtUI7mdQjL9HWoDnoAEQ8Gv8oxzjvbJv+n75f7l36m9Y8C7sCUltX3V5edndrp7Hp1oSXQ==",
-      "dev": true
-    },
-    "babel-helper-mark-eval-scopes": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.3.0.tgz",
-      "integrity": "sha512-nrho5Dg4vl0VUgURVpGpEGiwbst5JX7efIyDHFxmkCx/ocQFnrPt8ze9Kxl6TKjR29bJ7D/XKY1NMlSxOQJRbQ==",
-      "dev": true
     },
     "babel-helper-optimise-call-expression": {
       "version": "6.24.1",
@@ -4914,12 +4884,6 @@
         "babel-types": "^6.24.1"
       }
     },
-    "babel-helper-remove-or-void": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.3.0.tgz",
-      "integrity": "sha512-D68W1M3ibCcbg0ysh3ww4/O0g10X1CXK720oOuR8kpfY7w0yP4tVcpK7zDmI1JecynycTQYAZ1rhLJo9aVtIKQ==",
-      "dev": true
-    },
     "babel-helper-replace-supers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
@@ -4933,12 +4897,6 @@
         "babel-traverse": "^6.24.1",
         "babel-types": "^6.24.1"
       }
-    },
-    "babel-helper-to-multiple-sequence-expressions": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.3.0.tgz",
-      "integrity": "sha512-1uCrBD+EAaMnAYh7hc944n8Ga19y3daEnoXWPYDvFVsxMCc1l8aDjksApaCEaNSSuewq8BEcff47Cy1PbLg2Gw==",
-      "dev": true
     },
     "babel-helper-vue-jsx-merge-props": {
       "version": "2.0.3",
@@ -5351,17 +5309,6 @@
         "babel-runtime": "^6.22.0"
       }
     },
-    "babel-minify-webpack-plugin": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/babel-minify-webpack-plugin/-/babel-minify-webpack-plugin-0.3.1.tgz",
-      "integrity": "sha512-Johg6Ju0Gxevk2R55eutMqnyXwlyUzCtwunBpiyNzoxGnKum+x5nfNuYZYHGd5Bmc1gmhjwzb7GkxHWOtYWmtQ==",
-      "dev": true,
-      "requires": {
-        "babel-core": "^6.26.0",
-        "babel-preset-minify": "^0.3.0",
-        "webpack-sources": "^1.0.1"
-      }
-    },
     "babel-plugin-check-es2015-constants": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
@@ -5443,101 +5390,6 @@
       "dev": true,
       "requires": {
         "@types/babel__traverse": "^7.0.6"
-      }
-    },
-    "babel-plugin-minify-builtins": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.3.0.tgz",
-      "integrity": "sha512-MqhSHlxkmgURqj3144qPksbZ/qof1JWdumcbucc4tysFcf3P3V3z3munTevQgKEFNMd8F5/ECGnwb63xogLjAg==",
-      "dev": true,
-      "requires": {
-        "babel-helper-evaluate-path": "^0.3.0"
-      }
-    },
-    "babel-plugin-minify-constant-folding": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.3.0.tgz",
-      "integrity": "sha512-1XeRpx+aY1BuNY6QU/cm6P+FtEi3ar3XceYbmC+4q4W+2Ewq5pL7V68oHg1hKXkBIE0Z4/FjSoHz6vosZLOe/A==",
-      "dev": true,
-      "requires": {
-        "babel-helper-evaluate-path": "^0.3.0"
-      }
-    },
-    "babel-plugin-minify-dead-code-elimination": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.3.0.tgz",
-      "integrity": "sha512-SjM2Fzg85YZz+q/PNJ/HU4O3W98FKFOiP9K5z3sfonlamGOzvZw3Eup2OTiEBsbbqTeY8yzNCAv3qpJRYCgGmw==",
-      "dev": true,
-      "requires": {
-        "babel-helper-evaluate-path": "^0.3.0",
-        "babel-helper-mark-eval-scopes": "^0.3.0",
-        "babel-helper-remove-or-void": "^0.3.0",
-        "lodash.some": "^4.6.0"
-      }
-    },
-    "babel-plugin-minify-flip-comparisons": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.3.0.tgz",
-      "integrity": "sha512-B8lK+ekcpSNVH7PZpWDe5nC5zxjRiiT4nTsa6h3QkF3Kk6y9qooIFLemdGlqBq6j0zALEnebvCpw8v7gAdpgnw==",
-      "dev": true,
-      "requires": {
-        "babel-helper-is-void-0": "^0.3.0"
-      }
-    },
-    "babel-plugin-minify-guarded-expressions": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.3.0.tgz",
-      "integrity": "sha512-O+6CvF5/Ttsth3LMg4/BhyvVZ82GImeKMXGdVRQGK/8jFiP15EjRpdgFlxv3cnqRjqdYxLCS6r28VfLpb9C/kA==",
-      "dev": true,
-      "requires": {
-        "babel-helper-flip-expressions": "^0.3.0"
-      }
-    },
-    "babel-plugin-minify-infinity": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.3.0.tgz",
-      "integrity": "sha512-Sj8ia3/w9158DWieUxU6/VvnYVy59geeFEkVgLZYBE8EBP+sN48tHtBM/jSgz0ejEdBlcfqJ6TnvPmVXTzR2BQ==",
-      "dev": true
-    },
-    "babel-plugin-minify-mangle-names": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.3.0.tgz",
-      "integrity": "sha512-PYTonhFWURsfAN8achDwvR5Xgy6EeTClLz+fSgGRqjAIXb0OyFm3/xfccbQviVi1qDXmlSnt6oJhBg8KE4Fn7Q==",
-      "dev": true,
-      "requires": {
-        "babel-helper-mark-eval-scopes": "^0.3.0"
-      }
-    },
-    "babel-plugin-minify-numeric-literals": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.3.0.tgz",
-      "integrity": "sha512-TgZj6ay8zDw74AS3yiIfoQ8vRSNJisYO/Du60S8nPV7EW7JM6fDMx5Sar6yVHlVuuwNgvDUBh191K33bVrAhpg==",
-      "dev": true
-    },
-    "babel-plugin-minify-replace": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.3.0.tgz",
-      "integrity": "sha512-VR6tTg2Lt0TicHIOw04fsUtpPw7RaRP8PC8YzSFwEixnzvguZjZJoL7TgG7ZyEWQD1cJ96UezswECmFNa815bg==",
-      "dev": true
-    },
-    "babel-plugin-minify-simplify": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.3.0.tgz",
-      "integrity": "sha512-2M16ytQOCqBi7bYMu4DCWn8e6KyFCA108F6+tVrBJxOmm5u2sOmTFEa8s94tR9RHRRNYmcUf+rgidfnzL3ik9Q==",
-      "dev": true,
-      "requires": {
-        "babel-helper-flip-expressions": "^0.3.0",
-        "babel-helper-is-nodes-equiv": "^0.0.1",
-        "babel-helper-to-multiple-sequence-expressions": "^0.3.0"
-      }
-    },
-    "babel-plugin-minify-type-constructors": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.3.0.tgz",
-      "integrity": "sha512-XRXpvsUCPeVw9YEUw+9vSiugcSZfow81oIJT0yR9s8H4W7yJ6FHbImi5DJHoL8KcDUjYnL9wYASXk/fOkbyR6Q==",
-      "dev": true,
-      "requires": {
-        "babel-helper-is-void-0": "^0.3.0"
       }
     },
     "babel-plugin-syntax-async-functions": {
@@ -5827,39 +5679,6 @@
         "babel-runtime": "^6.22.0"
       }
     },
-    "babel-plugin-transform-inline-consecutive-adds": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.3.0.tgz",
-      "integrity": "sha512-iZsYAIjYLLfLK0yN5WVT7Xf7Y3wQ9Z75j9A8q/0IglQSpUt2ppTdHlwl/GeaXnxdaSmsxBu861klbTBbv2n+RA==",
-      "dev": true
-    },
-    "babel-plugin-transform-member-expression-literals": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.9.4.tgz",
-      "integrity": "sha1-NwOcmgwzE6OUlfqsL/OmtbnQOL8=",
-      "dev": true
-    },
-    "babel-plugin-transform-merge-sibling-variables": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.9.4.tgz",
-      "integrity": "sha1-hbQi/DN3tEnJ0c3kQIcgNTJAHa4=",
-      "dev": true
-    },
-    "babel-plugin-transform-minify-booleans": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.4.tgz",
-      "integrity": "sha1-rLs+VqNVXdI5KOS1gtKFFi3SsZg=",
-      "dev": true
-    },
-    "babel-plugin-transform-property-literals": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.9.4.tgz",
-      "integrity": "sha1-mMHSHiVXNlc/k+zlRFn2ziSYXTk=",
-      "dev": true,
-      "requires": {
-        "esutils": "^2.0.2"
-      }
-    },
     "babel-plugin-transform-regenerator": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
@@ -5882,39 +5701,6 @@
         }
       }
     },
-    "babel-plugin-transform-regexp-constructors": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.3.0.tgz",
-      "integrity": "sha512-h92YHzyl042rb0naKO8frTHntpRFwRgKkfWD8602kFHoQingjJNtbvZzvxqHncJ6XmKVyYvfrBpDOSkCTDIIxw==",
-      "dev": true
-    },
-    "babel-plugin-transform-remove-console": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
-      "integrity": "sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A=",
-      "dev": true
-    },
-    "babel-plugin-transform-remove-debugger": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.9.4.tgz",
-      "integrity": "sha1-QrcnYxyXl44estGZp67IShgznvI=",
-      "dev": true
-    },
-    "babel-plugin-transform-remove-undefined": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.3.0.tgz",
-      "integrity": "sha512-TYGQucc8iP3LJwN3kDZLEz5aa/2KuFrqpT+s8f8NnHsBU1sAgR3y8Opns0xhC+smyDYWscqFCKM1gbkWQOhhnw==",
-      "dev": true,
-      "requires": {
-        "babel-helper-evaluate-path": "^0.3.0"
-      }
-    },
-    "babel-plugin-transform-simplify-comparison-operators": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.4.tgz",
-      "integrity": "sha1-9ir+CWyrDh9ootdT/fKDiIRxzrk=",
-      "dev": true
-    },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
@@ -5924,12 +5710,6 @@
         "babel-runtime": "^6.22.0",
         "babel-types": "^6.24.1"
       }
-    },
-    "babel-plugin-transform-undefined-to-void": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz",
-      "integrity": "sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA=",
-      "dev": true
     },
     "babel-polyfill": {
       "version": "6.23.0",
@@ -6011,37 +5791,6 @@
       "requires": {
         "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
         "babel-plugin-jest-hoist": "^24.9.0"
-      }
-    },
-    "babel-preset-minify": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.3.0.tgz",
-      "integrity": "sha512-+VV2GWEyak3eDOmzT1DDMuqHrw3VbE9nBNkx2LLVs4pH/Me32ND8DRpVDd8IRvk1xX5p75nygyRPtkMh6GIAbQ==",
-      "dev": true,
-      "requires": {
-        "babel-plugin-minify-builtins": "^0.3.0",
-        "babel-plugin-minify-constant-folding": "^0.3.0",
-        "babel-plugin-minify-dead-code-elimination": "^0.3.0",
-        "babel-plugin-minify-flip-comparisons": "^0.3.0",
-        "babel-plugin-minify-guarded-expressions": "^0.3.0",
-        "babel-plugin-minify-infinity": "^0.3.0",
-        "babel-plugin-minify-mangle-names": "^0.3.0",
-        "babel-plugin-minify-numeric-literals": "^0.3.0",
-        "babel-plugin-minify-replace": "^0.3.0",
-        "babel-plugin-minify-simplify": "^0.3.0",
-        "babel-plugin-minify-type-constructors": "^0.3.0",
-        "babel-plugin-transform-inline-consecutive-adds": "^0.3.0",
-        "babel-plugin-transform-member-expression-literals": "^6.9.0",
-        "babel-plugin-transform-merge-sibling-variables": "^6.9.0",
-        "babel-plugin-transform-minify-booleans": "^6.9.0",
-        "babel-plugin-transform-property-literals": "^6.9.0",
-        "babel-plugin-transform-regexp-constructors": "^0.3.0",
-        "babel-plugin-transform-remove-console": "^6.9.0",
-        "babel-plugin-transform-remove-debugger": "^6.9.0",
-        "babel-plugin-transform-remove-undefined": "^0.3.0",
-        "babel-plugin-transform-simplify-comparison-operators": "^6.9.0",
-        "babel-plugin-transform-undefined-to-void": "^6.9.0",
-        "lodash.isplainobject": "^4.0.6"
       }
     },
     "babel-register": {
@@ -15851,12 +15600,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
       "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
-    },
-    "lodash.some": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
-      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0=",
-      "dev": true
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -230,7 +230,6 @@
     "babel-eslint": "^10.0.3",
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.0.5",
-    "babel-minify-webpack-plugin": "^0.3.1",
     "babel-plugin-istanbul": "^5.1.0",
     "babel-register": "^6.26.0",
     "cfonts": "^2.3.0",


### PR DESCRIPTION
## Description
I can't build because both of minify plugin and terser are enabled. So I removed `babel-minify-webpack-plugin`. In webpack@4 it is not required to specify minify plugin. In production codes are automatically minified in webpack.

## Related Issues
<!-- If there are related issues, please write issue number. -->

## Appearance
<!-- If you change the appearance, please paste the screen shots. -->
