### PR TITLE
Add bidi support

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -93,6 +93,7 @@ body,
   select,
   button {
     font-family: var(--specified-fonts);
+    unicode-bidi: plaintext;
   }
 }
 

--- a/src/renderer/components/organisms/Notification/Favourite.vue
+++ b/src/renderer/components/organisms/Notification/Favourite.vue
@@ -351,6 +351,10 @@ export default {
           word-wrap: break-word;
         }
 
+        .content p {
+          unicode-bidi: plaintext;
+        }
+
         .emojione {
           width: 20px;
           height: 20px;

--- a/src/renderer/components/organisms/Toot.vue
+++ b/src/renderer/components/organisms/Toot.vue
@@ -628,6 +628,10 @@ export default {
         word-wrap: break-word;
       }
 
+      .content p {
+        unicode-bidi: plaintext;
+      }
+
       .emojione {
         width: 20px;
         height: 20px;


### PR DESCRIPTION
## Description
Added support for bidirectional text so the app can handle intelligently the direction of each text. As the result, Whalebird can display LTR and RTL text in proper direction at the same time.

## Related Issues
issue no. #1058

## Appearance
![image](https://user-images.githubusercontent.com/11241315/74217098-2669f280-4cc4-11ea-85ad-96d7ac07c4a6.png)

![image](https://user-images.githubusercontent.com/11241315/74217176-5fa26280-4cc4-11ea-8bdd-50a9c06b7b80.png)

![New Toot](https://user-images.githubusercontent.com/11241315/74217508-44842280-4cc5-11ea-9f4e-8a7cc6ff5a09.png)


# Known Issues
Despite I have implemented this bidi support the exact same method I used for Sengi app (in which everything works perfect) here there are at least two known issues:
 - it breaks the appearance of URL in toots
 - It doesn't work properly in mentions

![image](https://user-images.githubusercontent.com/11241315/74217390-e22b2200-4cc4-11ea-9a56-9e47e30a2ac9.png)
![image](https://user-images.githubusercontent.com/11241315/74217459-130b5700-4cc5-11ea-8bb1-73535944b463.png)

Apart from these I haven't seen any other issue.