### PR TITLE
Fix word-wrap in pre tag in status

### DIFF
--- a/src/renderer/components/organisms/Toot.vue
+++ b/src/renderer/components/organisms/Toot.vue
@@ -712,6 +712,10 @@ export default {
       .content {
         margin: var(--toot-padding) 0;
         word-wrap: break-word;
+
+        pre {
+          white-space: pre-wrap;
+        }
       }
 
       .content p {


### PR DESCRIPTION
## Description
The contents is overflowed when there is a `pre` tag in status.

## Related Issues
<!-- If there are related issues, please write issue number. -->

## Appearance
Before:
![Screenshot from 2020-05-17 15-44-20](https://user-images.githubusercontent.com/4631959/82137714-702f1f80-9855-11ea-904c-0dd9ee050e0f.png)

After:
![Screenshot from 2020-05-17 15-44-31](https://user-images.githubusercontent.com/4631959/82137719-745b3d00-9855-11ea-946f-14cdd1894e2a.png)

