### PR TITLE
Fix options for css-loader 4.0.0

### DIFF
--- a/.electron-vue/webpack.renderer.config.js
+++ b/.electron-vue/webpack.renderer.config.js
@@ -31,19 +31,59 @@ let rendererConfig = {
       },
       {
         test: /\.scss$/,
-        use: ['vue-style-loader', 'css-loader', 'sass-loader']
+        use: [
+          'vue-style-loader',
+          {
+            loader: 'css-loader',
+            options: {
+              modules: false,
+              esModule: false
+            }
+          },
+          'sass-loader'
+        ]
       },
       {
         test: /\.sass$/,
-        use: ['vue-style-loader', 'css-loader', 'sass-loader?indentedSyntax']
+        use: [
+          'vue-style-loader',
+
+          {
+            loader: 'css-loader',
+            options: {
+              modules: false,
+              esModule: false
+            }
+          },
+          'sass-loader?indentedSyntax'
+        ]
       },
       {
         test: /\.less$/,
-        use: ['vue-style-loader', 'css-loader', 'less-loader']
+        use: [
+          'vue-style-loader',
+          {
+            loader: 'css-loader',
+            options: {
+              modules: false,
+              esModule: false
+            }
+          },
+          'less-loader'
+        ]
       },
       {
         test: /\.css$/,
-        use: ['vue-style-loader', 'css-loader']
+        use: [
+          'vue-style-loader',
+          {
+            loader: 'css-loader',
+            options: {
+              modules: false,
+              esModule: false
+            }
+          }
+        ]
       },
       {
         test: /\.html$/,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9997,30 +9997,30 @@
       "dev": true
     },
     "css-loader": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.6.0.tgz",
-      "integrity": "sha512-M5lSukoWi1If8dhQAUCvj4H8vUt3vOnwbQBH9DdTm/s4Ym2B/3dPMtYZeJmq7Q3S3Pa+I94DcZ7pc9bP14cWIQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-4.2.1.tgz",
+      "integrity": "sha512-MoqmF1if7Z0pZIEXA4ZF9PgtCXxWbfzfJM+3p+OYfhcrwcqhaCRb74DSnfzRl7e024xEiCRn5hCvfUbTf2sgFA==",
       "dev": true,
       "requires": {
-        "camelcase": "^5.3.1",
+        "camelcase": "^6.0.0",
         "cssesc": "^3.0.0",
         "icss-utils": "^4.1.1",
-        "loader-utils": "^1.2.3",
+        "loader-utils": "^2.0.0",
         "normalize-path": "^3.0.0",
         "postcss": "^7.0.32",
         "postcss-modules-extract-imports": "^2.0.0",
-        "postcss-modules-local-by-default": "^3.0.2",
+        "postcss-modules-local-by-default": "^3.0.3",
         "postcss-modules-scope": "^2.2.0",
         "postcss-modules-values": "^3.0.0",
         "postcss-value-parser": "^4.1.0",
         "schema-utils": "^2.7.0",
-        "semver": "^6.3.0"
+        "semver": "^7.3.2"
       },
       "dependencies": {
         "ajv-keywords": {
-          "version": "3.4.1",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
-          "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
           "dev": true
         },
         "ansi-styles": {
@@ -10039,9 +10039,9 @@
           "dev": true
         },
         "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+          "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
           "dev": true
         },
         "chalk": {
@@ -10073,23 +10073,23 @@
           "dev": true
         },
         "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "^1.2.5"
           }
         },
         "loader-utils": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
-            "json5": "^1.0.1"
+            "json5": "^2.1.2"
           }
         },
         "normalize-path": {
@@ -10127,9 +10127,9 @@
           }
         },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
           "dev": true
         },
         "source-map": {
@@ -21435,22 +21435,79 @@
       }
     },
     "postcss-modules-local-by-default": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.2.tgz",
-      "integrity": "sha512-jM/V8eqM4oJ/22j0gx4jrp63GSvDH6v86OqyTHHUvk4/k1vceipZsaymiZ5PvocqZOl5SFHiFJqjs3la0wnfIQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.3.tgz",
+      "integrity": "sha512-e3xDq+LotiGesympRlKNgaJ0PCzoUIdpH0dj47iWAui/kyTgh3CiAr1qP54uodmJhl6p9rN6BoNcdEDVJx9RDw==",
       "dev": true,
       "requires": {
         "icss-utils": "^4.1.1",
-        "postcss": "^7.0.16",
+        "postcss": "^7.0.32",
         "postcss-selector-parser": "^6.0.2",
-        "postcss-value-parser": "^4.0.0"
+        "postcss-value-parser": "^4.1.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "postcss": {
+          "version": "7.0.32",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
+          "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          }
+        },
         "postcss-value-parser": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
           "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
           "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -240,7 +240,7 @@
     "copy-webpack-plugin": "^6.0.3",
     "core-js": "^3.6.5",
     "cross-env": "^7.0.2",
-    "css-loader": "^3.6.0",
+    "css-loader": "^4.2.1",
     "del": "^5.1.0",
     "devtron": "^1.4.0",
     "electron": "9.1.2",

--- a/src/renderer/components/TimelineSpace/Contents/DirectMessages.vue
+++ b/src/renderer/components/TimelineSpace/Contents/DirectMessages.vue
@@ -57,7 +57,7 @@ export default {
       unreadNotification: state => state.TimelineSpace.unreadNotification
     }),
     ...mapGetters('TimelineSpace/Modals', ['modalOpened']),
-    shortcutEnabled: function() {
+    shortcutEnabled: function () {
       if (this.modalOpened) {
         return false
       }
@@ -83,7 +83,7 @@ export default {
       // If focusedId does not change, we have to refresh focusedId because Toot component watch change events.
       const previousFocusedId = this.focusedId
       this.focusedId = 0
-      this.$nextTick(function() {
+      this.$nextTick(function () {
         this.focusedId = previousFocusedId
       })
     })
@@ -113,14 +113,14 @@ export default {
     }
   },
   watch: {
-    startReload: function(newState, oldState) {
+    startReload: function (newState, oldState) {
       if (!oldState && newState) {
         this.reload().finally(() => {
           this.$store.commit('TimelineSpace/HeaderMenu/changeReload', false)
         })
       }
     },
-    focusedId: function(newState, _oldState) {
+    focusedId: function (newState, _oldState) {
       if (newState && this.heading) {
         this.$store.commit('TimelineSpace/Contents/DirectMessages/changeHeading', false)
       } else if (newState === null && !this.heading) {
@@ -253,4 +253,4 @@ export default {
   }
 }
 </style>
-<style src="@/assets/timeline-transition.scss"></style>
+<style lang="scss" src="@/assets/timeline-transition.scss"></style>

--- a/src/renderer/components/TimelineSpace/Contents/Hashtag/Tag.vue
+++ b/src/renderer/components/TimelineSpace/Contents/Hashtag/Tag.vue
@@ -55,7 +55,7 @@ export default {
       filter: state => state.TimelineSpace.Contents.Hashtag.Tag.filter
     }),
     ...mapGetters('TimelineSpace/Modals', ['modalOpened']),
-    shortcutEnabled: function() {
+    shortcutEnabled: function () {
       if (this.modalOpened) {
         return false
       }
@@ -78,27 +78,27 @@ export default {
       // If focusedId does not change, we have to refresh focusedId because Toot component watch change events.
       const previousFocusedId = this.focusedId
       this.focusedId = 0
-      this.$nextTick(function() {
+      this.$nextTick(function () {
         this.focusedId = previousFocusedId
       })
     })
   },
   watch: {
-    tag: function(newTag, _oldTag) {
+    tag: function (newTag, _oldTag) {
       this.$store.commit('TimelineSpace/Contents/changeLoading', true)
       this.reset()
       this.load(newTag).finally(() => {
         this.$store.commit('TimelineSpace/Contents/changeLoading', false)
       })
     },
-    startReload: function(newState, oldState) {
+    startReload: function (newState, oldState) {
       if (!oldState && newState) {
         this.reload().finally(() => {
           this.$store.commit('TimelineSpace/HeaderMenu/changeReload', false)
         })
       }
     },
-    focusedId: function(newState, _oldState) {
+    focusedId: function (newState, _oldState) {
       if (newState && this.heading) {
         this.$store.commit('TimelineSpace/Contents/Hashtag/Tag/changeHeading', false)
       } else if (newState === null && !this.heading) {
@@ -257,4 +257,4 @@ export default {
   transition: all 0.5s;
 }
 </style>
-<style src="@/assets/timeline-transition.scss"></style>
+<style lang="scss" src="@/assets/timeline-transition.scss"></style>

--- a/src/renderer/components/TimelineSpace/Contents/Home.vue
+++ b/src/renderer/components/TimelineSpace/Contents/Home.vue
@@ -234,4 +234,4 @@ export default {
   }
 }
 </style>
-<style src="@/assets/timeline-transition.scss"></style>
+<style lang="scss" src="@/assets/timeline-transition.scss"></style>

--- a/src/renderer/components/TimelineSpace/Contents/Lists/Show.vue
+++ b/src/renderer/components/TimelineSpace/Contents/Lists/Show.vue
@@ -55,7 +55,7 @@ export default {
       filter: state => state.TimelineSpace.Contents.Lists.Show.filter
     }),
     ...mapGetters('TimelineSpace/Modals', ['modalOpened']),
-    shortcutEnabled: function() {
+    shortcutEnabled: function () {
       if (this.modalOpened) {
         return false
       }
@@ -79,26 +79,26 @@ export default {
       // If focusedId does not change, we have to refresh focusedId because Toot component watch change events.
       const previousFocusedId = this.focusedId
       this.focusedId = 0
-      this.$nextTick(function() {
+      this.$nextTick(function () {
         this.focusedId = previousFocusedId
       })
     })
   },
   watch: {
-    list_id: function() {
+    list_id: function () {
       this.$store.commit('TimelineSpace/Contents/changeLoading', true)
       this.load().finally(() => {
         this.$store.commit('TimelineSpace/Contents/changeLoading', false)
       })
     },
-    startReload: function(newState, oldState) {
+    startReload: function (newState, oldState) {
       if (!oldState && newState) {
         this.reload().finally(() => {
           this.$store.commit('TimelineSpace/HeaderMenu/changeReload', false)
         })
       }
     },
-    focusedId: function(newState, _oldState) {
+    focusedId: function (newState, _oldState) {
       if (newState && this.heading) {
         this.$store.commit('TimelineSpace/Contents/Lists/Show/changeHeading', false)
       } else if (newState === null && !this.heading) {
@@ -257,4 +257,4 @@ export default {
   transition: all 0.5s;
 }
 </style>
-<style src="@/assets/timeline-transition.scss"></style>
+<style lang="scss" src="@/assets/timeline-transition.scss"></style>

--- a/src/renderer/components/TimelineSpace/Contents/Local.vue
+++ b/src/renderer/components/TimelineSpace/Contents/Local.vue
@@ -57,7 +57,7 @@ export default {
       unreadNotification: state => state.TimelineSpace.unreadNotification
     }),
     ...mapGetters('TimelineSpace/Modals', ['modalOpened']),
-    shortcutEnabled: function() {
+    shortcutEnabled: function () {
       if (this.modalOpened) {
         return false
       }
@@ -83,7 +83,7 @@ export default {
       // If focusedId does not change, we have to refresh focusedId because Toot component watch change events.
       const previousFocusedId = this.focusedId
       this.focusedId = 0
-      this.$nextTick(function() {
+      this.$nextTick(function () {
         this.focusedId = previousFocusedId
       })
     })
@@ -113,14 +113,14 @@ export default {
     }
   },
   watch: {
-    startReload: function(newState, oldState) {
+    startReload: function (newState, oldState) {
       if (!oldState && newState) {
         this.reload().finally(() => {
           this.$store.commit('TimelineSpace/HeaderMenu/changeReload', false)
         })
       }
     },
-    focusedId: function(newState, _oldState) {
+    focusedId: function (newState, _oldState) {
       if (newState && this.heading) {
         this.$store.commit('TimelineSpace/Contents/Local/changeHeading', false)
       } else if (newState === null && !this.heading) {
@@ -246,4 +246,4 @@ export default {
   }
 }
 </style>
-<style src="@/assets/timeline-transition.scss"></style>
+<style lang="scss" src="@/assets/timeline-transition.scss"></style>

--- a/src/renderer/components/TimelineSpace/Contents/Mentions.vue
+++ b/src/renderer/components/TimelineSpace/Contents/Mentions.vue
@@ -59,7 +59,7 @@ export default {
     }),
     ...mapGetters('TimelineSpace/Modals', ['modalOpened']),
     ...mapGetters('TimelineSpace/Contents/Mentions', ['mentions']),
-    shortcutEnabled: function() {
+    shortcutEnabled: function () {
       if (this.modalOpened) {
         return false
       }
@@ -78,7 +78,7 @@ export default {
       // If focusedId does not change, we have to refresh focusedId because Toot component watch change events.
       const previousFocusedId = this.focusedId
       this.focusedId = 0
-      this.$nextTick(function() {
+      this.$nextTick(function () {
         this.focusedId = previousFocusedId
       })
     })
@@ -101,14 +101,14 @@ export default {
     }
   },
   watch: {
-    startReload: function(newState, oldState) {
+    startReload: function (newState, oldState) {
       if (!oldState && newState) {
         this.reload().finally(() => {
           this.$store.commit('TimelineSpace/HeaderMenu/changeReload', false)
         })
       }
     },
-    focusedId: function(newState, _oldState) {
+    focusedId: function (newState, _oldState) {
       if (newState && this.heading) {
         this.$store.commit('TimelineSpace/Contents/Mentions/changeHeading', false)
       } else if (newState === null && !this.heading) {
@@ -225,4 +225,4 @@ export default {
   }
 }
 </style>
-<style src="@/assets/timeline-transition.scss"></style>
+<style lang="scss" src="@/assets/timeline-transition.scss"></style>

--- a/src/renderer/components/TimelineSpace/Contents/Notifications.vue
+++ b/src/renderer/components/TimelineSpace/Contents/Notifications.vue
@@ -53,7 +53,7 @@ export default {
       filter: state => state.TimelineSpace.Contents.Notifications.filter
     }),
     ...mapGetters('TimelineSpace/Modals', ['modalOpened']),
-    shortcutEnabled: function() {
+    shortcutEnabled: function () {
       if (this.modalOpened) {
         return false
       }
@@ -74,7 +74,7 @@ export default {
       // If focusedId does not change, we have to refresh focusedId because Toot component watch change events.
       const previousFocusedId = this.focusedId
       this.focusedId = 0
-      this.$nextTick(function() {
+      this.$nextTick(function () {
         this.focusedId = previousFocusedId
       })
     })
@@ -97,14 +97,14 @@ export default {
     }
   },
   watch: {
-    startReload: function(newState, oldState) {
+    startReload: function (newState, oldState) {
       if (!oldState && newState) {
         this.reload().finally(() => {
           this.$store.commit('TimelineSpace/HeaderMenu/changeReload', false)
         })
       }
     },
-    focusedId: function(newState, _oldState) {
+    focusedId: function (newState, _oldState) {
       if (newState >= 0 && this.heading) {
         this.$store.commit('TimelineSpace/Contents/Notifications/changeHeading', false)
       } else if (newState === null && !this.heading) {
@@ -225,4 +225,4 @@ export default {
   }
 }
 </style>
-<style src="@/assets/timeline-transition.scss"></style>
+<style lang="scss" src="@/assets/timeline-transition.scss"></style>

--- a/src/renderer/components/TimelineSpace/Contents/Public.vue
+++ b/src/renderer/components/TimelineSpace/Contents/Public.vue
@@ -57,7 +57,7 @@ export default {
       unreadNotification: state => state.TimelineSpace.unreadNotification
     }),
     ...mapGetters('TimelineSpace/Modals', ['modalOpened']),
-    shortcutEnabled: function() {
+    shortcutEnabled: function () {
       if (this.modalOpened) {
         return false
       }
@@ -83,7 +83,7 @@ export default {
       // If focusedId does not change, we have to refresh focusedId because Toot component watch change events.
       const previousFocusedId = this.focusedId
       this.focusedId = 0
-      this.$nextTick(function() {
+      this.$nextTick(function () {
         this.focusedId = previousFocusedId
       })
     })
@@ -113,14 +113,14 @@ export default {
     }
   },
   watch: {
-    startReload: function(newState, oldState) {
+    startReload: function (newState, oldState) {
       if (!oldState && newState) {
         this.reload().finally(() => {
           this.$store.commit('TimelineSpace/HeaderMenu/changeReload', false)
         })
       }
     },
-    focusedId: function(newState, _oldState) {
+    focusedId: function (newState, _oldState) {
       if (newState && this.heading) {
         this.$store.commit('TimelineSpace/Contents/Public/changeHeading', false)
       } else if (newState === null && !this.heading) {
@@ -246,4 +246,4 @@ export default {
   }
 }
 </style>
-<style src="@/assets/timeline-transition.scss"></style>
+<style lang="scss" src="@/assets/timeline-transition.scss"></style>


### PR DESCRIPTION
## Description
After I updated css-loader to 4.x.x, all style files are not loaded. But webpack does not say any errors.
The cause is that default values in css-loader's options are changed in 4.0.0: https://github.com/webpack-contrib/css-loader/releases/tag/v4.0.0

## Related Issues
refs: #1688 

## Appearance
<!-- If you change the appearance, please paste the screen shots. -->
