### PR TITLE
Fix window height of new toot when close window with some contents

### DIFF
--- a/src/renderer/components/TimelineSpace/Modals/NewToot.vue
+++ b/src/renderer/components/TimelineSpace/Modals/NewToot.vue
@@ -254,6 +254,10 @@ export default {
   methods: {
     close() {
       this.filteredAccount = []
+      const spoilerHeight = this.$refs.spoiler ? this.$refs.spoiler.offsetHeight : 0
+      this.showContentWarning = false
+      this.spoiler = ''
+      this.statusHeight = this.statusHeight + spoilerHeight
       const pollHeight = this.$refs.poll ? this.$refs.poll.$el.offsetHeight : 0
       this.openPoll = false
       this.polls = []

--- a/src/renderer/components/TimelineSpace/Modals/NewToot.vue
+++ b/src/renderer/components/TimelineSpace/Modals/NewToot.vue
@@ -254,12 +254,14 @@ export default {
   methods: {
     close() {
       this.filteredAccount = []
+      const pollHeight = this.$refs.poll ? this.$refs.poll.$el.offsetHeight : 0
       this.openPoll = false
       this.polls = []
       this.pollExpire = {
         label: this.$t('modals.new_toot.poll.expires.1_day'),
         value: 3600 * 24
       }
+      this.statusHeight = this.statusHeight + pollHeight
       this.$store.dispatch('TimelineSpace/Modals/NewToot/resetMediaCount')
       this.$store.dispatch('TimelineSpace/Modals/NewToot/closeModal')
     },

--- a/src/renderer/components/TimelineSpace/Modals/NewToot.vue
+++ b/src/renderer/components/TimelineSpace/Modals/NewToot.vue
@@ -266,6 +266,8 @@ export default {
         value: 3600 * 24
       }
       this.statusHeight = this.statusHeight + pollHeight
+      const attachmentHeight = this.$refs.preview ? this.$refs.preview.offsetHeight : 0
+      this.statusHeight = this.statusHeight + attachmentHeight
       this.$store.dispatch('TimelineSpace/Modals/NewToot/resetMediaCount')
       this.$store.dispatch('TimelineSpace/Modals/NewToot/closeModal')
     },

--- a/src/renderer/components/TimelineSpace/Modals/NewToot.vue
+++ b/src/renderer/components/TimelineSpace/Modals/NewToot.vue
@@ -266,6 +266,8 @@ export default {
         value: 3600 * 24
       }
       this.statusHeight = this.statusHeight + pollHeight
+      const quoteHeight = this.$refs.quote ? this.$refs.quote.$el.offsetHeight : 0
+      this.statusHeight = this.statusHeight + quoteHeight
       const attachmentHeight = this.$refs.preview ? this.$refs.preview.offsetHeight : 0
       this.statusHeight = this.statusHeight + attachmentHeight
       this.$store.dispatch('TimelineSpace/Modals/NewToot/resetMediaCount')


### PR DESCRIPTION
## Description
For example, I open new toot window and add poll form. Then I close the window, and reopen the window. In this time, the compose window does not have poll form, but window height contains poll form. 

So I have to clear poll form's height when close the window.

## Related Issues
<!-- If there are related issues, please write issue number. -->

## Appearance
<!-- If you change the appearance, please paste the screen shots. -->
