### PR TITLE
Clean up unused method calling

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -36,7 +36,6 @@ export default {
     this.$store.dispatch('App/loadPreferences').then(conf => {
       this.$i18n.i18next.changeLanguage(conf.language.language)
     })
-    this.$store.dispatch('App/loadProxy')
   },
   destroyed() {
     this.$store.dispatch('App/removeShortcutsEvents')


### PR DESCRIPTION
## Description
`App/loadProxy` is removed in https://github.com/h3poteto/whalebird-desktop/pull/1573
And it has not need.

## Related Issues
<!-- If there are related issues, please write issue number. -->

## Appearance
<!-- If you change the appearance, please paste the screen shots. -->
