### PR TITLE
refs #2244 Build mac arm64 dmg for Apple Silicon support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,9 @@ build: install
 mac:
 	yarn run package:mac
 	mv build/Whalebird-${VERSION}-mac.dmg build/Whalebird-${VERSION}-darwin-x64.dmg
+	mv build/Whalebird-${VERSION}-mac-arm64.dmg build/Whalebird-${VERSION}-darwin-arm64.dmg
 	cd build; shasum -a 256 Whalebird-${VERSION}-darwin-x64.dmg >> sha256sum.txt
+	cd build; shasum -a 256 Whalebird-${VERSION}-darwin-arm64.dmg >> sha256sum.txt
 
 mas:
 	yarn run build:mas

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build:win32": "yarn run build && yarn run package:win32",
     "build:win64": "yarn run build && yarn run package:win64",
     "build:mas": "yarn run build:clean && yarn run pack && electron-packager ./ 'Whalebird' --platform=mas --arch=x64 --electron-version=11.2.3 --asar.unpackDir='build/sounds' --out=packages --ignore='^/src' --ignore='^/.electron-vue' --ignore='^/.envrc' --ignore='^/packages' --ignore='^/plist' --ignore='^/static' --ignore='^/whalebird.db' --ignore='^/screenshot.png' --prune=true --icon=./build/icons/icon.icns --overwrite --app-bundle-id=org.whalebird.desktop --app-version=$npm_package_config_appVersion --build-version=$npm_package_config_buildVersion --extend-info='./plist/team.plist' --osx-sign --app-category-type=public.app-category.social-networking",
-    "package:mac": "electron-builder --mac --x64",
+    "package:mac": "electron-builder --mac",
     "package:linux": "electron-builder --linux",
     "package:win32": "electron-builder --win --ia32",
     "package:win64": "electron-builder --win --x64",
@@ -74,7 +74,13 @@
     "mac": {
       "icon": "build/icons/icon.icns",
       "target": [
-        "dmg"
+        {
+          "target": "dmg",
+          "arch": [
+            "x64",
+            "arm64"
+          ]
+        }
       ],
       "category": "public.app-category.social-networking"
     },


### PR DESCRIPTION
## Description
Update electron-builder configuration to build arm64 mac dmg. This pull request does not care MAS.


## Related Issues
refs #2244 

## Appearance
<!-- If you change the appearance, please paste the screen shots. -->
