### PR TITLE
Keep scroll position after merge new statuses in timeline

### DIFF
--- a/src/renderer/components/TimelineSpace/Contents.vue
+++ b/src/renderer/components/TimelineSpace/Contents.vue
@@ -1,7 +1,6 @@
 <template>
   <div id="contents" ref="contents" :style="customWidth" @mouseup="dragEnd" @mousemove="resize">
     <div
-      id="scrollable"
       :class="openSideBar ? 'timeline-wrapper-with-side-bar' : 'timeline-wrapper'"
       v-loading="loading"
       :element-loading-text="$t('message.loading')"
@@ -85,17 +84,11 @@ export default {
   .timeline-wrapper {
     height: 100%;
     width: 100%;
-    /* overflow: auto; */
-    /* transition: all 0.5s; */
-    /* scroll-behavior: auto; */
   }
 
   .timeline-wrapper-with-side-bar {
     height: 100%;
     width: calc(100% - var(--current-sidebar-width));
-    /* overflow: auto; */
-    /* transition: all 0.5s; */
-    /* scroll-behavior: auto; */
   }
 
   #resizer {

--- a/src/renderer/components/TimelineSpace/Contents.vue
+++ b/src/renderer/components/TimelineSpace/Contents.vue
@@ -85,17 +85,17 @@ export default {
   .timeline-wrapper {
     height: 100%;
     width: 100%;
-    overflow: auto;
-    transition: all 0.5s;
-    scroll-behavior: auto;
+    /* overflow: auto; */
+    /* transition: all 0.5s; */
+    /* scroll-behavior: auto; */
   }
 
   .timeline-wrapper-with-side-bar {
     height: 100%;
     width: calc(100% - var(--current-sidebar-width));
-    overflow: auto;
-    transition: all 0.5s;
-    scroll-behavior: auto;
+    /* overflow: auto; */
+    /* transition: all 0.5s; */
+    /* scroll-behavior: auto; */
   }
 
   #resizer {

--- a/src/renderer/components/TimelineSpace/Contents/Favourites.vue
+++ b/src/renderer/components/TimelineSpace/Contents/Favourites.vue
@@ -191,6 +191,7 @@ export default {
   height: 100%;
   overflow: auto;
   scroll-behavior: auto;
+
   .scroller {
     height: 100%;
   }

--- a/src/renderer/components/TimelineSpace/Contents/Hashtag.vue
+++ b/src/renderer/components/TimelineSpace/Contents/Hashtag.vue
@@ -1,62 +1,69 @@
 <template>
-<div id="hashtag">
-  <div class="search-header" v-loading="false">
-    <el-form>
-      <div class="form-wrapper">
-        <div class="form-item" v-show="tagPage()">
-          <el-button type="text" @click="back">
-            <icon name="chevron-left"></icon>
-          </el-button>
+  <div id="hashtag">
+    <div class="search-header" v-loading="false">
+      <el-form>
+        <div class="form-wrapper">
+          <div class="form-item" v-show="tagPage()">
+            <el-button type="text" @click="back">
+              <icon name="chevron-left"></icon>
+            </el-button>
+          </div>
+          <div class="form-item input">
+            <input
+              v-model="tag"
+              :placeholder="$t('hashtag.tag_name')"
+              class="search-keyword"
+              v-shortkey.avoid
+              v-on:keyup.enter="search"
+              autofocus
+            />
+          </div>
+          <div class="form-item" v-show="tagPage()">
+            <el-button type="text" @click="save" :title="$t('hashtag.save_tag')">
+              <icon name="thumbtack"></icon>
+            </el-button>
+          </div>
         </div>
-        <div class="form-item input">
-          <input v-model="tag" :placeholder="$t('hashtag.tag_name')" class="search-keyword" v-shortkey.avoid v-on:keyup.enter="search" autofocus></input>
-        </div>
-        <div class="form-item" v-show="tagPage()">
-          <el-button type="text" @click="save" :title="$t('hashtag.save_tag')">
-            <icon name="thumbtack"></icon>
-          </el-button>
-        </div>
-      </div>
-    </el-form>
+      </el-form>
+    </div>
+    <router-view></router-view>
   </div>
-  <router-view></router-view>
-</div>
 </template>
 
 <script>
 export default {
   name: 'hashtag',
-  data () {
+  data() {
     return {
       tag: ''
     }
   },
-  mounted () {
+  mounted() {
     if (this.$route.name === 'tag') {
       this.tag = this.$route.params.tag
     }
   },
   watch: {
-    '$route': function (route) {
+    $route: function (route) {
       if (route.name === 'tag') {
         this.tag = route.params.tag
       }
     }
   },
   methods: {
-    id () {
+    id() {
       return this.$route.params.id
     },
-    search () {
+    search() {
       this.$router.push({ path: `/${this.id()}/hashtag/${this.tag}` })
     },
-    tagPage () {
+    tagPage() {
       return this.$route.name === 'tag'
     },
-    back () {
+    back() {
       this.$router.push({ path: `/${this.id()}/hashtag` })
     },
-    save () {
+    save() {
       this.$store.dispatch('TimelineSpace/Contents/Hashtag/saveTag', this.tag)
     }
   }
@@ -66,6 +73,8 @@ export default {
 <style lang="scss" scoped>
 #hashtag {
   border-top: 1px solid var(--theme-border-color);
+  height: calc(100% - 1px);
+  overflow: hidden;
 
   .search-header {
     background-color: var(--theme-selected-background-color);

--- a/src/renderer/components/TimelineSpace/Contents/Hashtag/Tag.vue
+++ b/src/renderer/components/TimelineSpace/Contents/Hashtag/Tag.vue
@@ -1,14 +1,15 @@
 <template>
-  <div name="tag" v-shortkey="shortcutEnabled ? { next: ['j'] } : {}" @shortkey="handleKey">
+  <div name="tag" class="tag-timeline" v-shortkey="shortcutEnabled ? { next: ['j'] } : {}" @shortkey="handleKey">
     <div class="unread">{{ unread.length > 0 ? unread.length : '' }}</div>
     <div v-shortkey="{ linux: ['ctrl', 'r'], mac: ['meta', 'r'] }" @shortkey="reload()"></div>
-    <DynamicScroller :items="timeline" :min-item-size="60" class="scroller" page-mode>
+    <DynamicScroller :items="timeline" :min-item-size="60" id="scroller" class="scroller" ref="scroller">
       <template v-slot="{ item, index, active }">
         <DynamicScrollerItem :item="item" :active="active" :size-dependencies="[item.uri]" :data-index="index" :watchData="true">
           <toot
             :message="item"
             :focused="item.uri + item.id === focusedId"
             :overlaid="modalOpened"
+            :filters="[]"
             v-on:update="updateToot"
             v-on:delete="deleteToot"
             @focusNext="focusNext"
@@ -20,7 +21,6 @@
         </DynamicScrollerItem>
       </template>
     </DynamicScroller>
-    <div class="loading-card" v-loading="lazyLoading" :element-loading-background="backgroundColor"></div>
     <div :class="openSideBar ? 'upper-with-side-bar' : 'upper'" v-show="!heading">
       <el-button type="primary" icon="el-icon-arrow-up" @click="upper" circle> </el-button>
     </div>
@@ -30,7 +30,6 @@
 <script>
 import { mapState, mapGetters } from 'vuex'
 import Toot from '~/src/renderer/components/organisms/Toot'
-import scrollTop from '../../../utils/scroll'
 import reloadable from '~/src/renderer/components/mixins/reloadable'
 import { Event } from '~/src/renderer/components/event'
 
@@ -72,7 +71,7 @@ export default {
     this.load(this.tag).finally(() => {
       this.$store.commit('TimelineSpace/Contents/changeLoading', false)
     })
-    document.getElementById('scrollable').addEventListener('scroll', this.onScroll)
+    document.getElementById('scroller').addEventListener('scroll', this.onScroll)
 
     Event.$on('focus-timeline', () => {
       // If focusedId does not change, we have to refresh focusedId because Toot component watch change events.
@@ -133,9 +132,9 @@ export default {
       this.$store.commit('TimelineSpace/Contents/Hashtag/Tag/mergeTimeline')
       this.$store.commit('TimelineSpace/Contents/Hashtag/Tag/archiveTimeline')
       this.$store.commit('TimelineSpace/Contents/Hashtag/Tag/clearTimeline')
-      if (document.getElementById('scrollable') !== undefined && document.getElementById('scrollable') !== null) {
-        document.getElementById('scrollable').removeEventListener('scroll', this.onScroll)
-        document.getElementById('scrollable').scrollTop = 0
+      if (document.getElementById('scroller') !== undefined && document.getElementById('scroller') !== null) {
+        document.getElementById('scroller').removeEventListener('scroll', this.onScroll)
+        document.getElementById('scroller').scrollTop = 0
       }
     },
     updateToot(toot) {
@@ -146,7 +145,7 @@ export default {
     },
     onScroll(event) {
       if (
-        event.target.clientHeight + event.target.scrollTop >= document.getElementsByName('tag')[0].clientHeight - 10 &&
+        event.target.clientHeight + event.target.scrollTop >= document.getElementById('scroller').scrollHeight - 10 &&
         !this.lazyloading
       ) {
         this.$store.dispatch('TimelineSpace/Contents/Hashtag/Tag/lazyFetchTimeline', {
@@ -155,11 +154,15 @@ export default {
         })
       }
       // for unread control
-      if (event.target.scrollTop > 10 && this.heading) {
+      if (event.target.scrollTop > 5 && this.heading) {
         this.$store.commit('TimelineSpace/Contents/Hashtag/Tag/changeHeading', false)
-      } else if (event.target.scrollTop <= 10 && !this.heading) {
-        this.$store.commit('TimelineSpace/Contents/Hashtag/Tag/changeHeading', true)
+      } else if (event.target.scrollTop <= 5 && !this.heading) {
+        const currentPos = this.unread.length
+        if (currentPos === 0) {
+          this.$store.commit('TimelineSpace/Contents/Hashtag/Tag/changeHeading', true)
+        }
         this.$store.commit('TimelineSpace/Contents/Hashtag/Tag/mergeTimeline')
+        this.$refs.scroller.scrollToItem(currentPos)
       }
     },
     async reload() {
@@ -185,7 +188,7 @@ export default {
       }
     },
     upper() {
-      scrollTop(document.getElementById('scrollable'), 0)
+      this.$refs.scroller.scrollToItem(0)
       this.focusedId = null
     },
     focusNext() {
@@ -222,39 +225,42 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.unread {
-  position: fixed;
-  right: 24px;
-  top: 48px;
-  background-color: rgba(0, 0, 0, 0.7);
-  color: #ffffff;
-  padding: 4px 8px;
-  border-radius: 0 0 2px 2px;
+.tag-timeline {
+  height: 100%;
+  overflow: auto;
+  scroll-behavior: auto;
 
-  &:empty {
-    display: none;
+  .scroller {
+    height: 100%;
   }
-}
 
-.loading-card {
-  height: 60px;
-}
+  .unread {
+    position: fixed;
+    right: 24px;
+    top: 48px;
+    background-color: rgba(0, 0, 0, 0.7);
+    color: #ffffff;
+    padding: 4px 8px;
+    border-radius: 0 0 2px 2px;
+    z-index: 1;
 
-.loading-card:empty {
-  height: 0;
-}
+    &:empty {
+      display: none;
+    }
+  }
 
-.upper {
-  position: fixed;
-  bottom: 20px;
-  right: 20px;
-}
+  .upper {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+  }
 
-.upper-with-side-bar {
-  position: fixed;
-  bottom: 20px;
-  right: calc(20px + var(--current-sidebar-width));
-  transition: all 0.5s;
+  .upper-with-side-bar {
+    position: fixed;
+    bottom: 20px;
+    right: calc(20px + var(--current-sidebar-width));
+    transition: all 0.5s;
+  }
 }
 </style>
 <style lang="scss" src="@/assets/timeline-transition.scss"></style>

--- a/src/renderer/components/TimelineSpace/Contents/Home.vue
+++ b/src/renderer/components/TimelineSpace/Contents/Home.vue
@@ -156,7 +156,6 @@ export default {
         this.$store.commit('TimelineSpace/Contents/Home/changeHeading', false)
       } else if (event.target.scrollTop <= 5 && !this.heading) {
         const currentPos = this.unread.length
-        console.log(currentPos)
         if (currentPos === 0) {
           this.$store.commit('TimelineSpace/Contents/Home/changeHeading', true)
         }

--- a/src/renderer/components/TimelineSpace/Contents/Home.vue
+++ b/src/renderer/components/TimelineSpace/Contents/Home.vue
@@ -2,7 +2,7 @@
   <div id="home" v-shortkey="shortcutEnabled ? { next: ['j'] } : {}" @shortkey="handleKey">
     <div class="unread">{{ unread.length > 0 ? unread.length : '' }}</div>
     <div v-shortkey="{ linux: ['ctrl', 'r'], mac: ['meta', 'r'] }" @shortkey="reload()"></div>
-    <DynamicScroller :items="filteredTimeline" :min-item-size="60" class="scroller" page-mode>
+    <DynamicScroller :items="filteredTimeline" :min-item-size="60" id="scroller" class="scroller" ref="scroller">
       <template v-slot="{ item, index, active }">
         <DynamicScrollerItem :item="item" :active="active" :size-dependencies="[item.uri]" :data-index="index" :watchData="true">
           <toot
@@ -21,7 +21,7 @@
         </DynamicScrollerItem>
       </template>
     </DynamicScroller>
-    <div class="loading-card" v-loading="lazyLoading" :element-loading-background="backgroundColor"></div>
+
     <div :class="openSideBar ? 'upper-with-side-bar' : 'upper'" v-show="!heading">
       <el-button type="primary" icon="el-icon-arrow-up" @click="upper" circle> </el-button>
     </div>
@@ -31,7 +31,6 @@
 <script>
 import { mapState, mapGetters } from 'vuex'
 import Toot from '~/src/renderer/components/organisms/Toot'
-import scrollTop from '../../utils/scroll'
 import reloadable from '~/src/renderer/components/mixins/reloadable'
 import { Event } from '~/src/renderer/components/event'
 
@@ -85,7 +84,7 @@ export default {
   },
   mounted() {
     this.$store.commit('TimelineSpace/SideMenu/changeUnreadHomeTimeline', false)
-    document.getElementById('scrollable').addEventListener('scroll', this.onScroll)
+    document.getElementById('scroller').addEventListener('scroll', this.onScroll)
     Event.$on('focus-timeline', () => {
       // If focusedId does not change, we have to refresh focusedId because Toot component watch change events.
       const previousFocusedId = this.focusedId
@@ -111,9 +110,9 @@ export default {
     this.$store.commit('TimelineSpace/Contents/Home/changeHeading', true)
     this.$store.commit('TimelineSpace/Contents/Home/mergeTimeline')
     this.$store.commit('TimelineSpace/Contents/Home/archiveTimeline')
-    if (document.getElementById('scrollable') !== undefined && document.getElementById('scrollable') !== null) {
-      document.getElementById('scrollable').removeEventListener('scroll', this.onScroll)
-      document.getElementById('scrollable').scrollTop = 0
+    if (document.getElementById('scroller') !== undefined && document.getElementById('scroller') !== null) {
+      document.getElementById('scroller').removeEventListener('scroll', this.onScroll)
+      document.getElementById('scroller').scrollTop = 0
     }
   },
   watch: {
@@ -141,7 +140,10 @@ export default {
   methods: {
     onScroll(event) {
       // for lazyLoading
-      if (event.target.clientHeight + event.target.scrollTop >= document.getElementById('home').clientHeight - 10 && !this.lazyloading) {
+      if (
+        event.target.clientHeight + event.target.scrollTop >= document.getElementById('scroller').scrollHeight - 10 &&
+        !this.lazyloading
+      ) {
         this.$store.dispatch('TimelineSpace/Contents/Home/lazyFetchTimeline', this.timeline[this.timeline.length - 1]).catch(() => {
           this.$message({
             message: this.$t('message.timeline_fetch_error'),
@@ -152,9 +154,14 @@ export default {
       // for unread control
       if (event.target.scrollTop > 10 && this.heading) {
         this.$store.commit('TimelineSpace/Contents/Home/changeHeading', false)
-      } else if (event.target.scrollTop <= 10 && !this.heading) {
-        this.$store.commit('TimelineSpace/Contents/Home/changeHeading', true)
+      } else if (event.target.scrollTop <= 5 && !this.heading) {
+        const currentPos = this.unread.length
+        console.log(currentPos)
+        if (currentPos === 0) {
+          this.$store.commit('TimelineSpace/Contents/Home/changeHeading', true)
+        }
         this.$store.commit('TimelineSpace/Contents/Home/mergeTimeline')
+        this.$refs.scroller.scrollToItem(currentPos)
       }
     },
     updateToot(message) {
@@ -172,7 +179,7 @@ export default {
       }
     },
     upper() {
-      scrollTop(document.getElementById('scrollable'), 0)
+      this.$refs.scroller.scrollToItem(0)
       this.focusedId = null
     },
     focusNext() {
@@ -210,6 +217,14 @@ export default {
 
 <style lang="scss" scoped>
 #home {
+  height: 100%;
+  overflow: auto;
+  scroll-behavior: auto;
+
+  .scroller {
+    height: 100%;
+  }
+
   .unread {
     position: fixed;
     right: 24px;

--- a/src/renderer/components/TimelineSpace/Contents/Home.vue
+++ b/src/renderer/components/TimelineSpace/Contents/Home.vue
@@ -218,6 +218,7 @@ export default {
     color: #ffffff;
     padding: 4px 8px;
     border-radius: 0 0 2px 2px;
+    z-index: 1;
 
     &:empty {
       display: none;

--- a/src/renderer/components/TimelineSpace/Contents/Lists/Show.vue
+++ b/src/renderer/components/TimelineSpace/Contents/Lists/Show.vue
@@ -1,14 +1,15 @@
 <template>
-  <div name="list" v-shortkey="shortcutEnabled ? { next: ['j'] } : {}" @shortkey="handleKey">
+  <div name="list" class="list-timeline" v-shortkey="shortcutEnabled ? { next: ['j'] } : {}" @shortkey="handleKey">
     <div class="unread">{{ unread.length > 0 ? unread.length : '' }}</div>
     <div v-shortkey="{ linux: ['ctrl', 'r'], mac: ['meta', 'r'] }" @shortkey="reload()"></div>
-    <DynamicScroller :items="timeline" :min-item-size="60" class="scroller" page-mode>
+    <DynamicScroller :items="timeline" :min-item-size="60" id="scroller" class="scroller" ref="scroller">
       <template v-slot="{ item, index, active }">
         <DynamicScrollerItem :item="item" :active="active" :size-dependencies="[item.uri]" :data-index="index" :watchData="true">
           <toot
             :message="item"
             :focused="item.uri + item.id === focusedId"
             :overlaid="modalOpened"
+            :filters="[]"
             v-on:update="updateToot"
             v-on:delete="deleteToot"
             @focusNext="focusNext"
@@ -20,7 +21,6 @@
         </DynamicScrollerItem>
       </template>
     </DynamicScroller>
-    <div class="loading-card" v-loading="lazyLoading" :element-loading-background="backgroundColor"></div>
     <div :class="openSideBar ? 'upper-with-side-bar' : 'upper'" v-show="!heading">
       <el-button type="primary" icon="el-icon-arrow-up" @click="upper" circle> </el-button>
     </div>
@@ -30,7 +30,6 @@
 <script>
 import { mapState, mapGetters } from 'vuex'
 import Toot from '~/src/renderer/components/organisms/Toot'
-import scrollTop from '../../../utils/scroll'
 import reloadable from '~/src/renderer/components/mixins/reloadable'
 import { Event } from '~/src/renderer/components/event'
 
@@ -72,9 +71,9 @@ export default {
     this.load().finally(() => {
       this.$store.commit('TimelineSpace/Contents/changeLoading', false)
     })
-    document.getElementById('scrollable').addEventListener('scroll', this.onScroll)
   },
   mounted() {
+    document.getElementById('scroller').addEventListener('scroll', this.onScroll)
     Event.$on('focus-timeline', () => {
       // If focusedId does not change, we have to refresh focusedId because Toot component watch change events.
       const previousFocusedId = this.focusedId
@@ -115,9 +114,9 @@ export default {
     this.$store.commit('TimelineSpace/Contents/Lists/Show/mergeTimeline')
     this.$store.commit('TimelineSpace/Contents/Lists/Show/archiveTimeline')
     this.$store.commit('TimelineSpace/Contents/Lists/Show/clearTimeline')
-    if (document.getElementById('scrollable') !== undefined && document.getElementById('scrollable') !== null) {
-      document.getElementById('scrollable').removeEventListener('scroll', this.onScroll)
-      document.getElementById('scrollable').scrollTop = 0
+    if (document.getElementById('scroller') !== undefined && document.getElementById('scroller') !== null) {
+      document.getElementById('scroller').removeEventListener('scroll', this.onScroll)
+      document.getElementById('scroller').scrollTop = 0
     }
   },
   methods: {
@@ -147,7 +146,7 @@ export default {
     },
     onScroll(event) {
       if (
-        event.target.clientHeight + event.target.scrollTop >= document.getElementsByName('list')[0].clientHeight - 10 &&
+        event.target.clientHeight + event.target.scrollTop >= document.getElementById('scroller').scrollHeight - 10 &&
         !this.lazyloading
       ) {
         this.$store.dispatch('TimelineSpace/Contents/Lists/Show/lazyFetchTimeline', {
@@ -156,11 +155,15 @@ export default {
         })
       }
       // for unread control
-      if (event.target.scrollTop > 10 && this.heading) {
+      if (event.target.scrollTop > 5 && this.heading) {
         this.$store.commit('TimelineSpace/Contents/Lists/Show/changeHeading', false)
-      } else if (event.target.scrollTop <= 10 && !this.heading) {
-        this.$store.commit('TimelineSpace/Contents/Lists/Show/changeHeading', true)
+      } else if (event.target.scrollTop <= 5 && !this.heading) {
+        const currentPos = this.unread.length
+        if (currentPos === 0) {
+          this.$store.commit('TimelineSpace/Contents/Lists/Show/changeHeading', true)
+        }
         this.$store.commit('TimelineSpace/Contents/Lists/Show/mergeTimeline')
+        this.$refs.scroller.scrollToItem(currentPos)
       }
     },
     async reload() {
@@ -185,7 +188,7 @@ export default {
       }
     },
     upper() {
-      scrollTop(document.getElementById('scrollable'), 0)
+      this.$refs.scroller.scrollToItem(0)
       this.focusedId = null
     },
     focusNext() {
@@ -222,39 +225,42 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.unread {
-  position: fixed;
-  right: 24px;
-  top: 48px;
-  background-color: rgba(0, 0, 0, 0.7);
-  color: #ffffff;
-  padding: 4px 8px;
-  border-radius: 0 0 2px 2px;
+.list-timeline {
+  height: 100%;
+  overflow: auto;
+  scroll-behavior: auto;
 
-  &:empty {
-    display: none;
+  .scroller {
+    height: 100%;
   }
-}
 
-.loading-card {
-  height: 60px;
-}
+  .unread {
+    position: fixed;
+    right: 24px;
+    top: 48px;
+    background-color: rgba(0, 0, 0, 0.7);
+    color: #ffffff;
+    padding: 4px 8px;
+    border-radius: 0 0 2px 2px;
+    z-index: 1;
 
-.loading-card:empty {
-  height: 0;
-}
+    &:empty {
+      display: none;
+    }
+  }
 
-.upper {
-  position: fixed;
-  bottom: 20px;
-  right: 20px;
-}
+  .upper {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+  }
 
-.upper-with-side-bar {
-  position: fixed;
-  bottom: 20px;
-  right: calc(20px + var(--current-sidebar-width));
-  transition: all 0.5s;
+  .upper-with-side-bar {
+    position: fixed;
+    bottom: 20px;
+    right: calc(20px + var(--current-sidebar-width));
+    transition: all 0.5s;
+  }
 }
 </style>
 <style lang="scss" src="@/assets/timeline-transition.scss"></style>

--- a/src/renderer/components/TimelineSpace/Contents/Local.vue
+++ b/src/renderer/components/TimelineSpace/Contents/Local.vue
@@ -2,13 +2,14 @@
   <div id="local" v-shortkey="shortcutEnabled ? { next: ['j'] } : {}" @shortkey="handleKey">
     <div class="unread">{{ unread.length > 0 ? unread.length : '' }}</div>
     <div v-shortkey="{ linux: ['ctrl', 'r'], mac: ['meta', 'r'] }" @shortkey="reload()"></div>
-    <DynamicScroller :items="timeline" :min-item-size="60" class="scroller" page-mode>
+    <DynamicScroller :items="timeline" :min-item-size="60" id="scroller" class="scroller" ref="scroller">
       <template v-slot="{ item, index, active }">
         <DynamicScrollerItem :item="item" :active="active" :size-dependencies="[item.uri]" :data-index="index" :watchData="true">
           <toot
             :message="item"
             :focused="item.uri + item.id === focusedId"
             :overlaid="modalOpened"
+            :filters="[]"
             v-on:update="updateToot"
             v-on:delete="deleteToot"
             @focusNext="focusNext"
@@ -20,7 +21,6 @@
         </DynamicScrollerItem>
       </template>
     </DynamicScroller>
-    <div class="loading-card" v-loading="lazyLoading" :element-loading-background="backgroundColor"></div>
     <div :class="openSideBar ? 'upper-with-side-bar' : 'upper'" v-show="!heading">
       <el-button type="primary" icon="el-icon-arrow-up" @click="upper" circle> </el-button>
     </div>
@@ -30,7 +30,6 @@
 <script>
 import { mapState, mapGetters } from 'vuex'
 import Toot from '~/src/renderer/components/organisms/Toot'
-import scrollTop from '../../utils/scroll'
 import reloadable from '~/src/renderer/components/mixins/reloadable'
 import { Event } from '~/src/renderer/components/event'
 
@@ -71,7 +70,7 @@ export default {
   },
   async mounted() {
     this.$store.commit('TimelineSpace/SideMenu/changeUnreadLocalTimeline', false)
-    document.getElementById('scrollable').addEventListener('scroll', this.onScroll)
+    document.getElementById('scroller').addEventListener('scroll', this.onScroll)
     if (!this.unreadNotification.local) {
       this.$store.commit('TimelineSpace/Contents/changeLoading', true)
       await this.initialize().finally(_ => {
@@ -107,9 +106,9 @@ export default {
     if (!this.unreadNotification.local) {
       this.$store.commit('TimelineSpace/Contents/Local/clearTimeline')
     }
-    if (document.getElementById('scrollable') !== undefined && document.getElementById('scrollable') !== null) {
-      document.getElementById('scrollable').removeEventListener('scroll', this.onScroll)
-      document.getElementById('scrollable').scrollTop = 0
+    if (document.getElementById('scroller') !== undefined && document.getElementById('scroller') !== null) {
+      document.getElementById('scroller').removeEventListener('scroll', this.onScroll)
+      document.getElementById('scroller').scrollTop = 0
     }
   },
   watch: {
@@ -147,7 +146,10 @@ export default {
       this.$store.commit('TimelineSpace/Contents/Local/deleteToot', message.id)
     },
     onScroll(event) {
-      if (event.target.clientHeight + event.target.scrollTop >= document.getElementById('local').clientHeight - 10 && !this.lazyloading) {
+      if (
+        event.target.clientHeight + event.target.scrollTop >= document.getElementById('scroller').scrollHeight - 10 &&
+        !this.lazyloading
+      ) {
         this.$store.dispatch('TimelineSpace/Contents/Local/lazyFetchTimeline', this.timeline[this.timeline.length - 1]).catch(() => {
           this.$message({
             message: this.$t('message.timeline_fetch_error'),
@@ -156,11 +158,15 @@ export default {
         })
       }
       // for unread control
-      if (event.target.scrollTop > 10 && this.heading) {
+      if (event.target.scrollTop > 5 && this.heading) {
         this.$store.commit('TimelineSpace/Contents/Local/changeHeading', false)
-      } else if (event.target.scrollTop <= 10 && !this.heading) {
-        this.$store.commit('TimelineSpace/Contents/Local/changeHeading', true)
+      } else if (event.target.scrollTop <= 5 && !this.heading) {
+        const currentPos = this.unread.length
+        if (currentPos === 0) {
+          this.$store.commit('TimelineSpace/Contents/Local/changeHeading', true)
+        }
         this.$store.commit('TimelineSpace/Contents/Local/mergeTimeline')
+        this.$refs.scroller.scrollToItem(currentPos)
       }
     },
     async reload() {
@@ -172,7 +178,7 @@ export default {
       }
     },
     upper() {
-      scrollTop(document.getElementById('scrollable'), 0)
+      this.$refs.scroller.scrollToItem(0)
       this.focusedId = null
     },
     focusNext() {
@@ -210,6 +216,14 @@ export default {
 
 <style lang="scss" scoped>
 #local {
+  height: 100%;
+  overflow: auto;
+  scroll-behavior: auto;
+
+  .scroller {
+    height: 100%;
+  }
+
   .unread {
     position: fixed;
     right: 24px;
@@ -218,6 +232,7 @@ export default {
     color: #ffffff;
     padding: 4px 8px;
     border-radius: 0 0 2px 2px;
+    z-index: 1;
 
     &:empty {
       display: none;


### PR DESCRIPTION
## Description
At the moment, scroll to top when merge new statuses in timeline. 

New statuses are merged when I returned top of the timeline, after I scroll down the timeline. But, new statuses are merged and scroll to top of the timeline which includes new statuses. So I lost the position at that time.

- [x] Home
- [x] Notifications
- [x] Mention
- [x] DirectMessages
- [x] Favourites
- [x] Bookmarks
- [x] Local
- [x] Public
- [x] Tags
- [x] Lists

## Related Issues
<!-- If there are related issues, please write issue number. -->

## Appearance
<!-- If you change the appearance, please paste the screen shots. -->
