### PR TITLE
add support of integers in TLD (closes #2313)

### DIFF
--- a/src/renderer/utils/validator.js
+++ b/src/renderer/utils/validator.js
@@ -1,1 +1,1 @@
-export const domainFormat = /^[a-zA-Z0-9][a-zA-Z0-9-.]{0,61}[a-zA-Z0-9]\.[a-zA-Z]{2,}$/
+export const domainFormat = /^[a-zA-Z0-9][a-zA-Z0-9-.]{0,61}[a-zA-Z0-9]\.[a-zA-Z0-9]{2,}$/


### PR DESCRIPTION
## Description
That PR fixes support of TLDs with integers in it (like `.i2p`)

## Related Issues
#2313