### PR TITLE
Stop building linux ia32 build because Electron 19 does not support it

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -81,7 +81,6 @@
         "target": "tar.bz2",
         "arch": [
           "x64",
-          "ia32",
           "armv7l",
           "arm64"
         ]


### PR DESCRIPTION
## Description
https://github.com/h3poteto/whalebird-desktop/runs/8252368640?check_suite_focus=true
Faild to build linux ia32, because Electron 19.x does not provide linux-ia32 build.
https://github.com/electron/electron/releases/tag/v19.0.15

So, we also stop supporting linux ia32.

## Related Issues
<!-- If there are related issues, please write the issue number. -->

## Appearance
<!-- If you change the appearance, please paste the screenshots. -->
