### PR TITLE
add some space between display name and handle

### DIFF
--- a/src/renderer/components/organisms/Toot.vue
+++ b/src/renderer/components/organisms/Toot.vue
@@ -834,6 +834,10 @@ export default defineComponent({
         overflow: hidden;
         text-overflow: ellipsis;
 
+        span ~ span {
+          padding-left: 0.5em;
+        }
+
         .display-name {
           font-weight: 800;
           color: var(--theme-primary-color);


### PR DESCRIPTION
## Description
There was no space between display name and user handle so I added some.

## Appearance
<img width="331" alt="image" src="https://user-images.githubusercontent.com/33906/200117634-25786177-56f7-4fb0-81fb-fd166918f0d1.png">