### PR TITLE
update domainFormat validation to accept single character domains like c.im

### DIFF
--- a/spec/renderer/unit/utils/validator.spec.ts
+++ b/spec/renderer/unit/utils/validator.spec.ts
@@ -2,6 +2,13 @@ import { domainFormat } from '@/utils/validator'
 
 describe('validator', () => {
   describe('domainFormat', () => {
+    describe('single character domain name', () => {
+      const domain = 'c.im'
+      it('should match', () => {
+        const res = domain.search(domainFormat)
+        expect(res).toEqual(0)
+      })
+    })
     describe('string contains protocol', () => {
       const domain = 'https://mastodon.social'
       it('should not match', () => {

--- a/src/renderer/utils/validator.ts
+++ b/src/renderer/utils/validator.ts
@@ -1,1 +1,2 @@
+// eslint-disable-next-line
 export const domainFormat = /^(((?!\-))(xn\-\-)?[a-z0-9\-_]{0,61}[a-z0-9]{1,1}\.)*(xn\-\-)?([a-z0-9\-]{1,61}|[a-z0-9\-]{1,30})\.[a-z]{2,}$/


### PR DESCRIPTION
## Description
The current regex fails to detect domains consisting of a single character.  

This patch replaces the regex in validator.ts with one that found consensus on [StackOverflow](https://stackoverflow.com/questions/10306690/what-is-a-regular-expression-which-will-match-a-valid-domain-name-without-a-subd) for matching domains and optional subdomains, and also accounts for the single character case.

## Related Issues
3722