### PR TITLE
Add hide-to-tray on start option

### DIFF
--- a/spec/renderer/integration/store/Preferences/General.spec.ts
+++ b/spec/renderer/integration/store/Preferences/General.spec.ts
@@ -19,7 +19,8 @@ const state = (): GeneralState => {
         hideAllAttachments: false
       },
       other: {
-        launch: false
+        launch: false,
+        hideOnLaunch: false
       }
     },
     loading: false

--- a/spec/renderer/unit/store/Preferences/General.spec.ts
+++ b/spec/renderer/unit/store/Preferences/General.spec.ts
@@ -15,7 +15,8 @@ describe('Preferences/General', () => {
           hideAllAttachments: false
         },
         other: {
-          launch: false
+          launch: false,
+          hideOnLaunch: false
         }
       },
       loading: false

--- a/src/config/locales/en/translation.json
+++ b/src/config/locales/en/translation.json
@@ -172,7 +172,8 @@
       },
       "other": {
         "title": "Other options",
-        "launch": "Launch app on login"
+        "launch": "Launch app on login",
+        "hideOnLaunch": "Hide window on launch"
       },
       "reset": {
         "button": "Reset preferences"

--- a/src/constants/initializer/preferences.ts
+++ b/src/constants/initializer/preferences.ts
@@ -24,7 +24,8 @@ const timeline: Timeline = {
 }
 
 const other: Other = {
-  launch: false
+  launch: false,
+  hideOnLaunch: false
 }
 
 const general: General = {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -51,6 +51,7 @@ import ProxyConfiguration from './proxy'
 import confirm from './timelines'
 import { EnabledTimelines } from '~/src/types/enabledTimelines'
 import { Menu as MenuPreferences } from '~/src/types/preference'
+import { General as GeneralPreferences } from '~/src/types/preference'
 import { LocalMarker } from '~/src/types/localMarker'
 import Marker from './marker'
 import newDB from './database'
@@ -225,6 +226,12 @@ const getMenuPreferences = async (): Promise<MenuPreferences> => {
   return conf.menu
 }
 
+const getGeneralPreferences = async (): Promise<GeneralPreferences> => {
+  const preferences = new Preferences(preferencesDBPath)
+  const conf = await preferences.load()
+  return conf.general
+}
+
 /**
  * Set application menu
  * @return Whether the menu bar is auto hide.
@@ -280,6 +287,11 @@ async function createWindow() {
    * Get spellcheck
    */
   const spellcheck = await getSpellChecker()
+
+  /**
+   * Get general preferences
+   */
+  const generalPreferences = await getGeneralPreferences()
 
   /**
    * Load system theme color for dark mode
@@ -391,6 +403,15 @@ async function createWindow() {
       mainWindow!.setSkipTaskbar(true)
       event.preventDefault()
     })
+
+    // Minimize to tray immediately if "hide on launch" selected
+    // or if --hidden arg is passed
+    if ((generalPreferences.other.hideOnLaunch || args.hidden) && !args.show) {
+      mainWindow.once('show', () => {
+        mainWindow!.hide()
+        mainWindow!.setSkipTaskbar(true)
+      })
+    }
   } else {
     mainWindow.on('closed', () => {
       mainWindow = null
@@ -409,6 +430,8 @@ Usage
 
 Options
  --help    show help
+ --hidden  start Whalebird hidden to tray
+ --show    start Whalebird with a window
 `)
   process.exit(0)
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -408,8 +408,8 @@ async function createWindow() {
     // or if --hidden arg is passed
     if ((generalPreferences.other.hideOnLaunch || args.hidden) && !args.show) {
       mainWindow.once('show', () => {
-        mainWindow!.hide()
-        mainWindow!.setSkipTaskbar(true)
+        mainWindow?.hide()
+        mainWindow?.setSkipTaskbar(true)
       })
     }
   } else {

--- a/src/renderer/components/Preferences/General.vue
+++ b/src/renderer/components/Preferences/General.vue
@@ -33,6 +33,9 @@
       <el-form-item for="launch" :label="$t('preferences.general.other.launch')">
         <el-switch id="launch" v-model="other_launch" active-color="#13ce66"> </el-switch>
       </el-form-item>
+      <el-form-item for="hideOnLaunch" :label="$t('preferences.general.other.hideOnLaunch')">
+        <el-switch id="hideOnLaunch" v-model="other_hideOnLaunch" active-color="#13ce66"> </el-switch>
+      </el-form-item>
     </el-form>
     <el-form class="reset section">
       <el-button type="info" @click="reset">{{ $t('preferences.general.reset.button') }}</el-button>
@@ -99,6 +102,13 @@ export default defineComponent({
           launch: value
         })
     })
+    const other_hideOnLaunch = computed({
+      get: () => store.state.Preferences.General.general.other.hideOnLaunch,
+      set: (value: boolean) =>
+        store.dispatch(`${space}/${ACTION_TYPES.UPDATE_OTHER}`, {
+          hideOnLaunch: value
+        })
+    })
 
     onMounted(() => {
       store.dispatch(`${space}/${ACTION_TYPES.LOAD_GENERAL}`).catch(() => {
@@ -133,6 +143,7 @@ export default defineComponent({
       timeline_nsfw,
       timeline_hide_attachments,
       other_launch,
+      other_hideOnLaunch,
       reset
     }
   }

--- a/src/renderer/store/Preferences/General.ts
+++ b/src/renderer/store/Preferences/General.ts
@@ -25,7 +25,8 @@ const state = (): GeneralState => ({
       hideAllAttachments: false
     },
     other: {
-      launch: false
+      launch: false,
+      hideOnLaunch: false
     }
   },
   loading: false

--- a/src/types/preference.ts
+++ b/src/types/preference.ts
@@ -7,6 +7,7 @@ import { Proxy } from '~/src/types/proxy'
 
 export type Other = {
   launch: boolean
+  hideOnLaunch: boolean
 }
 
 export type General = {


### PR DESCRIPTION
## Description

Implements a _hide on start_ option to minimize the window to tray on app launch.

This uses the same minimize technique as the `onClose` hook and the tray icon toggle, and occurs after the browser window load and splash screen finish.

Additional command line arguments `--hidden` and `--show` override the menu setting (for autorun/cron etc.).

The menu option exists as `Hide window on launch` under _Preferences/General/Other_.

### Notes

+ I generally work with C#/.NET/PowerShell and am unfamiliar with electron/node/ts. Please check that I haven't missed anything.
+ I've only added a language string for the menu item to the English locale, so translations will need to be made for `preferences/general/other/hideOnLaunch`.

## Related Issues

- Resolves #2660

## Appearance

Updated Preferences menu:

![image](https://user-images.githubusercontent.com/10586436/209172293-1e168fff-2b0b-439b-8551-553141e8ef0f.png)

