### PR TITLE
Give reviewdog permission to review

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -3,6 +3,9 @@ name: reviewdog
 on:
   pull_request:
 
+permissions:
+  pull-requests: write
+
 jobs:
   eslint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://docs.github.com/en/rest/overview/permissions-required-for-github-apps?apiVersion=2022-11-28#pull-requests

## Description
<!-- Please write a description. For example, why did you change this? -->
Each organization can set its own default permissions. The organization where I staged the work for #3952 doesn't include write permissions by default, and thus reviewdog breaks when it tries to complain about https://github.com/h3poteto/whalebird-desktop/pull/3952#discussion_r1057360990 (see https://github.com/check-spelling/whalebird-desktop/pull/1#discussion_r1057359360)

## Related Issues
<!-- If there are related issues, please write the issue number. -->

## Appearance
<!-- If you change the appearance, please paste the screenshots. -->
