### PR TITLE
Remove armv7l from production build

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -81,7 +81,6 @@
         "target": "tar.bz2",
         "arch": [
           "x64",
-          "armv7l",
           "arm64"
         ]
       },


### PR DESCRIPTION
## Description
Could not build armv7 with sqlite3.

## Related Issues
<!-- If there are related issues, please write the issue number. -->

## Appearance
<!-- If you change the appearance, please paste the screenshots. -->
