### PR TITLE
Copyedit and harmonize EN language strings

### DIFF
--- a/src/config/locales/en/translation.json
+++ b/src/config/locales/en/translation.json
@@ -3,18 +3,18 @@
     "application": {
       "name": "Whalebird",
       "about": "About Whalebird",
-      "preferences": "Preferences...",
-      "shortcuts": "Shortcut Keys",
+      "preferences": "Preferences",
+      "shortcuts": "Keyboard shortcuts",
       "services": "Services",
       "hide": "Hide Whalebird",
-      "hide_others": "Hide Others",
-      "show_all": "Show All",
-      "open": "Open Window",
+      "hide_others": "Hide others",
+      "show_all": "Show all",
+      "open": "Open window",
       "quit": "Quit"
     },
     "toot": {
-      "name": "Toot",
-      "new": "New Toot"
+      "name": "Posts",
+      "new": "New post..."
     },
     "edit": {
       "name": "Edit",
@@ -27,10 +27,10 @@
     },
     "view": {
       "name": "View",
-      "toggle_full_screen": "Toggle Full Screen"
+      "toggle_full_screen": "Toggle full screen"
     },
     "window": {
-      "always_show_menu_bar": "Always Show Menu Bar",
+      "always_show_menu_bar": "Always show menubar",
       "name": "Window",
       "close": "Close Window",
       "open": "Open Window",
@@ -45,41 +45,41 @@
     "profile": "Profile",
     "show_profile": "Show profile",
     "edit_profile": "Edit profile",
-    "settings": "Account Settings",
+    "settings": "Account settings",
     "collapse": "Collapse",
     "expand": "Expand",
     "home": "Home",
-    "notification": "Notification",
+    "notification": "Notifications",
     "direct": "Direct messages",
-    "follow_requests": "Follow Requests",
-    "favourite": "Favourite",
-    "bookmark": "Bookmark",
+    "follow_requests": "Follow requests",
+    "favourite": "Favorited",
+    "bookmark": "Bookmarks",
     "local": "Local timeline",
     "public": "Public timeline",
-    "hashtag": "Hashtag",
+    "hashtag": "Hashtags",
     "search": "Search",
     "lists": "Lists"
   },
   "header_menu": {
     "home": "Home",
-    "notification": "Notification",
-    "favourite": "Favourite",
-    "bookmark": "Bookmark",
-    "follow_requests": "Follow Requests",
-    "direct_messages": "Direct Messages",
+    "notification": "Notifications",
+    "favourite": "Favorited",
+    "bookmark": "Bookmarks",
+    "follow_requests": "Follow requests",
+    "direct_messages": "Direct messages",
     "local": "Local timeline",
     "public": "Public timeline",
-    "hashtag": "Hashtag",
+    "hashtag": "Hashtags",
     "search": "Search",
     "lists": "Lists",
     "members": "Members",
     "option": {
       "title": "Option",
-      "show_reblogs": "Show reblogs",
+      "show_reblogs": "Show boosts",
       "show_replies": "Show replies",
       "apply": "Apply"
     },
-    "new_toot": "Toot",
+    "new_toot": "Publish",
     "reload": "Reload",
     "settings": "Settings"
   },
@@ -88,10 +88,10 @@
     "general": {
       "title": "General",
       "toot": {
-        "title": "Toot",
+        "title": "Posts",
         "visibility": {
-          "description": "Customize default visibility of toot",
-          "notice": "This setting applies to only new toots, replies follow visibility of original toots",
+          "description": "Customize default visibility of post",
+          "notice": "This setting applies only to new posts; replies will follow the visibility of the original post.",
           "public": "Public",
           "unlisted": "Unlisted",
           "private": "Private",
@@ -105,11 +105,11 @@
     "timeline": {
       "title": "Timeline",
       "unread_notification": {
-        "title": "Unread Notification",
+        "title": "Unread notifications",
         "description": "Customize unread notifications for each timeline.",
-        "direct": "Direct Messages",
-        "local": "Local Timeline",
-        "public": "Public Timeline"
+        "direct": "Direct messages",
+        "local": "Local timeline",
+        "public": "Public timeline"
       },
       "use_marker": {
         "title": "Load the timeline from the last reading position",
@@ -145,7 +145,7 @@
       },
       "delete": {
         "title": "Delete",
-        "confirm": "Are you sure to delete this filter?",
+        "confirm": "Are you sure you want to delete this filter?",
         "confirm_ok": "Delete",
         "confirm_cancel": "Cancel"
       }
@@ -157,21 +157,21 @@
       "title": "General",
       "sounds": {
         "title": "Sounds",
-        "description": "Please set feedback sounds.",
-        "fav_rb": "When you favorite or boost the toot",
-        "toot": "When you post toot"
+        "description": "Play sounds when",
+        "fav_rb": "You favorite or boost a post",
+        "toot": "You make a post"
       },
       "timeline": {
         "title": "Timeline",
-        "description": "Customize view in your timelines.",
-        "cw": "Always expand posts marked with contents warnings",
-        "nsfw": "Always show all media",
-        "hideAllAttachments": "Always hide all media"
+        "description": "Customize how your timelines are displayed",
+        "cw": "Always expand posts tagged with content warnings.",
+        "nsfw": "Always show media.",
+        "hideAllAttachments": "Always hide media."
       },
       "other": {
         "title": "Other options",
-        "launch": "Launch app on login",
-        "hideOnLaunch": "Hide window on launch"
+        "launch": "Launch Whalebird on startup",
+        "hideOnLaunch": "Hide the Whalebird window on launch"
       },
       "reset": {
         "button": "Reset preferences"
@@ -199,13 +199,13 @@
         "secondary_color": "Secondary font",
         "border_color": "Border",
         "header_menu_color": "Header menu",
-        "wrapper_mask_color": "Modal wrapper"
+        "wrapper_mask_color": "Dialog wrapper"
       },
       "font_size": "Font size",
       "font_family": "Font family",
-      "toot_padding": "Padding around toots",
+      "toot_padding": "Padding around posts",
       "display_style": {
-        "title": "Display style of username",
+        "title": "Username display style",
         "display_name_and_username": "Display name and username",
         "display_name": "Display name",
         "username": "Username"
@@ -217,23 +217,23 @@
       }
     },
     "notification": {
-      "title": "Notification",
+      "title": "Notifications",
       "enable": {
-        "description": "Please set notification events.",
-        "reply": "Notify me when I receive a reply",
-        "reblog": "Notify me when I receive a reblog",
-        "favourite": "Notify me when I receive a favourite",
-        "follow": "Notify me when I receive a follow",
-        "reaction": "Notify me when I receive a emoji reaction",
-        "follow_request": "Notify me when I receive a follow request",
-        "status": "Notify me when I receive a status notification",
-        "poll_vote": "Notify me when I receive a vote of poll",
-        "poll_expired": "Notify me when I receive a poll expired event"
+        "description": "Notify me when I receive...",
+        "reply": "Replies",
+        "reblog": "Boosts",
+        "favourite": "Favorites",
+        "follow": "New followers",
+        "reaction": "Emoji reactions",
+        "follow_request": "Follow requests",
+        "status": "Status notifications",
+        "poll_vote": "When someone votes in a poll",
+        "poll_expired": "When a poll expires"
       }
     },
     "account": {
       "title": "Account",
-      "connected": "Connected Account",
+      "connected": "Connected accounts",
       "username": "Username",
       "domain": "Domain",
       "association": "Association",
@@ -247,7 +247,7 @@
     "network": {
       "title": "Network",
       "proxy": {
-        "title": "Proxy Configuration",
+        "title": "Proxy configuration",
         "no": "No proxy",
         "system": "Use system proxy",
         "manual": "Manual proxy configuration",
@@ -275,31 +275,31 @@
       },
       "spellchecker": {
         "title": "Spellcheck",
-        "enabled": "Enable spellchecker"
+        "enabled": "Enable spell checker"
       }
     }
   },
   "modals": {
     "new_toot": {
-      "title": "New Toot",
+      "title": "New post",
       "cw": "Write your warning here",
-      "status": "What is on your mind?",
+      "status": "What's on your mind?",
       "cancel": "Cancel",
-      "toot": "Toot",
-      "close_confirm": "Are you sure you want to discard this toot?",
+      "toot": "Publish",
+      "close_confirm": "Are you sure you want to discard this post?",
       "close_confirm_ok": "Discard",
-      "close_confirm_cancel": "Continue Editing",
-      "description": "Describe for the visually impaired",
+      "close_confirm_cancel": "Continue editing",
+      "description": "Add alternate text for this media",
       "footer": {
         "add_image": "Add images",
         "poll": "Add a poll",
         "change_visibility": "Change visibility",
         "change_sensitive": "Mark media as sensitive",
-        "add_cw": "Add content warning",
-        "pined_hashtag": "Pin the hashtag"
+        "add_cw": "Add content warnings",
+        "pined_hashtag": "Pin a hashtag"
       },
       "poll": {
-        "add_choice": "Add a choice",
+        "add_choice": "Add an option",
         "expires": {
           "5_minutes": "5 minutes",
           "30_minutes": "30 minutes",
@@ -315,15 +315,15 @@
       "jump_to": "Jump to..."
     },
     "add_list_member": {
-      "title": "Add Member to List",
+      "title": "Add member to List",
       "account_name": "Account name"
     },
     "list_membership": {
-      "title": "List Memberships"
+      "title": "List memberships"
     },
     "mute_confirm": {
-      "title": "Are you sure you want to mute?",
-      "body": "Hide notification from this user?",
+      "title": "Mute user",
+      "body": "Are you sure you want to mute notifications from this user?",
       "cancel": "Cancel",
       "ok": "Mute"
     },
@@ -331,25 +331,25 @@
       "title": "Keyboard shortcuts",
       "ctrl_number": "Switch accounts",
       "ctrl_k": "Jump to other timelines",
-      "ctrl_n": "Open the new toot modal",
-      "ctrl_enter": "Post the toot",
-      "ctrl_r": "Reload current timeline",
-      "j": "Select the next toot",
-      "k": "Select the previous toot",
+      "ctrl_n": "Open the new post dialog",
+      "ctrl_enter": "Publish the post",
+      "ctrl_r": "Refresh current timeline",
+      "j": "Select the next post",
+      "k": "Select the previous post",
       "h": "Switch focus to the left column",
       "l": "Switch focus to the right column",
-      "r": "Reply to the toot",
-      "b": "Reblog the toot",
-      "f": "Favourite the toot",
-      "o": "Open details of the toot",
-      "p": "Open account profile of the toot",
+      "r": "Reply to the post",
+      "b": "Boost the post",
+      "f": "Favourite the post",
+      "o": "Open the post's details",
+      "p": "Display the profile of the post's author",
       "i": "Open the images",
-      "x": "Show/hide CW and NSFW",
-      "?": "Show this help",
+      "x": "Expand/hide content warned posts",
+      "?": "Show this dialog",
       "esc": "Close current page"
     },
     "report": {
-      "title": "Reporting this user",
+      "title": "Report this user",
       "comment": "Additional comments",
       "cancel": "Cancel",
       "ok": "Report"
@@ -360,20 +360,20 @@
       "show_more": "Show more",
       "hide": "Hide",
       "sensitive": "Show sensitive content",
-      "view_toot_detail": "View Toot Detail",
-      "open_in_browser": "Open in Browser",
-      "copy_link_to_toot": "Copy Link to Toot",
+      "view_toot_detail": "View post details",
+      "open_in_browser": "Open in browser",
+      "copy_link_to_toot": "Copy post link",
       "mute": "Mute",
       "block": "Block",
       "report": "Report",
       "delete": "Delete",
       "via": "via {{application}}",
       "reply": "Reply",
-      "reblog": "Reblog",
-      "fav": "Favourite",
-      "detail": "Toot details",
+      "reblog": "Boost",
+      "fav": "Favorite",
+      "detail": "Post details",
       "bookmark": "Bookmark",
-      "pinned": "Pinned toot",
+      "pinned": "Pinned post",
       "poll": {
         "vote": "Vote",
         "votes_count": "votes",
@@ -383,7 +383,7 @@
       },
       "open_account": {
         "title": "Account not found",
-        "text": "Could not find {{account}} in the server. Do you want to open the account in the browser instead?",
+        "text": "Could not find {{account}} on the server. Do you want to open the account in a browser instead?",
         "ok": "Open",
         "cancel": "Cancel"
       }
@@ -402,13 +402,13 @@
       "subscribe": "Subscribe this user",
       "unsubscribe": "Unsubscribe this user",
       "follow_requested": "Follow requested",
-      "open_in_browser": "Open in Browser",
-      "manage_list_memberships": "Manage List Memberships",
+      "open_in_browser": "Open in browser",
+      "manage_list_memberships": "Manage list memberships",
       "mute": "Mute",
       "unmute": "Unmute",
       "unblock": "Unblock",
       "block": "Block",
-      "toots": "Toots",
+      "toots": "Posts",
       "follows": "Follows",
       "followers": "Followers"
     }
@@ -426,8 +426,8 @@
     "search": "Search",
     "account": "Account",
     "tag": "Hashtag",
-    "keyword": "keyword",
-    "toot": "Toot"
+    "keyword": "Keyword",
+    "toot": "Post"
   },
   "lists": {
     "index": {
@@ -436,7 +436,7 @@
       "delete": {
         "confirm": {
           "title": "Confirm",
-          "message": "This operation can not be undone, this list will be permanently deleted",
+          "message": "This list will be permanently deleted. Are you sure you want to continue?",
           "ok": "Delete",
           "cancel": "Cancel"
         }
@@ -444,21 +444,21 @@
     }
   },
   "login": {
-    "domain_name_label": "First, let's log in to a Mastodon server. Please enter a server domain name.",
-    "proxy_info": "If you want to use proxy server, please setup your proxy in",
+    "domain_name_label": "Welcome to Whalebird! Enter a server domain name to log into an account.",
+    "proxy_info": "If you need to use a proxy server, please set it up",
     "proxy_here": " here",
     "search": "Search",
     "login": "Login"
   },
   "authorize": {
     "manually_1": "An authorization page has opened in your browser.",
-    "manually_2": "If it has not opened, please go to the following URL manually.",
-    "code_label": "Please paste the authorization code from your browser:",
+    "manually_2": "If it has not yet opened, please go to the following URL manually:",
+    "code_label": "Enter your authorization code:",
     "misskey_label": "Please submit after you authorize in your browser.",
     "submit": "Submit"
   },
   "receive_drop": {
-    "drop_message": "Drop to Upload a file"
+    "drop_message": "Drop here to attach a file"
   },
   "message": {
     "account_load_error": "Failed to load accounts",
@@ -475,7 +475,7 @@
     "authorize_error": "Failed to authorize",
     "followers_fetch_error": "Failed to fetch followers",
     "follows_fetch_error": "Failed to fetch follows",
-    "toot_fetch_error": "Failed to fetch the toot detail",
+    "toot_fetch_error": "Failed to fetch the post details",
     "follow_error": "Failed to follow the user",
     "unfollow_error": "Failed to unfollow the user",
     "subscribe_error": "Failed to subscribe the user",
@@ -485,22 +485,22 @@
     "members_fetch_error": "Failed to fetch members",
     "remove_user_error": "Failed to remove the user",
     "find_account_error": "Account not found",
-    "reblog_error": "Failed to reblog",
-    "unreblog_error": "Failed to unreblog",
+    "reblog_error": "Failed to boost",
+    "unreblog_error": "Failed to unboost",
     "favourite_error": "Failed to favourite",
     "unfavourite_error": "Failed to unfavourite",
     "bookmark_error": "Failed to bookmark",
     "unbookmark_error": "Failed to remove bookmark",
-    "delete_error": "Failed to delete the toot",
+    "delete_error": "Failed to delete the post",
     "search_error": "Failed to search",
-    "toot_error": "Failed to toot",
+    "toot_error": "Failed to create the post",
     "update_list_memberships_error": "Failed to update the list memberships",
     "add_user_error": "Failed to add user",
     "authorize_url_error": "Failed to get authorize url",
-    "domain_confirmed": "{{domain}} is confirmed, please login",
-    "domain_doesnt_exist": "Failed to connect {{domain}}, make sure the server URL",
+    "domain_confirmed": "{{domain}} is confirmed, please log in",
+    "domain_doesnt_exist": "Failed to connect to {{domain}}, make sure the server URL is valid or correct.",
     "loading": "Loading...",
-    "language_not_support_spellchecker_error": "This language is not supported by Spellchecker",
+    "language_not_support_spellchecker_error": "This language is not supported by the spell checker",
     "update_filter_error": "Failed to update the filter",
     "create_filter_error": "Failed to create the filter"
   },
@@ -510,7 +510,7 @@
       "domain_format": "Please only enter the domain name"
     },
     "new_toot": {
-      "toot_length": "Toot length should be {{min}} to {{max}}",
+      "toot_length": "Post length should be between {{min}} and {{max}}",
       "attach_length": "You can only attach up to {{max}} image",
       "attach_length_plural": "You can only attach up to {{max}} images",
       "attach_image": "You can only attach images or videos",
@@ -519,40 +519,40 @@
   },
   "notification": {
     "favourite": {
-      "title": "Favourite",
-      "body": "{{username}} favourited your status"
+      "title": "New favourite",
+      "body": "{{username}} favourited your post"
     },
     "follow": {
-      "title": "Follow",
+      "title": "New follower",
       "body": "{{username}} is now following you"
     },
     "follow_request": {
-      "title": "FollowRequest",
-      "body": "Receive a follow request from {{username}}"
+      "title": "New follow request",
+      "body": "Received a follow request from {{username}}"
     },
     "reblog": {
-      "title": "Reblog",
-      "body": "{{username}} boosted your status"
+      "title": "New boost",
+      "body": "{{username}} boosted your post"
     },
     "quote": {
-      "title": "Quote",
-      "body": "{{username}} quoted your status"
+      "title": "New quote",
+      "body": "{{username}} quoted your post"
     },
     "reaction": {
-      "title": "Reaction",
-      "body": "{{username}} reacted your status"
+      "title": "New reaction",
+      "body": "{{username}} reacted to your post"
     },
     "status": {
-      "title": "Status",
-      "body": "{{username}} just posted"
+      "title": "New reaction",
+      "body": "{{username}} made a new post"
     },
     "poll_vote": {
-      "title": "PollVote",
-      "body": "{{username}} voted your poll"
+      "title": "New poll vote",
+      "body": "{{username}} voted in your poll"
     },
     "poll_expired": {
-      "title": "PollExpired",
-      "body": "{{username}}'s poll is expired"
+      "title": "Poll expired",
+      "body": "{{username}}'s poll has ended"
     }
   }
 }

--- a/src/config/locales/en/translation.json
+++ b/src/config/locales/en/translation.json
@@ -91,7 +91,7 @@
         "title": "Posts",
         "visibility": {
           "description": "Customize default visibility of post",
-          "notice": "This setting applies only to new posts; replies will follow the visibility of the original post.",
+          "notice": "This setting applies only to new posts; replies will follow the visibility settings of the parent post.",
           "public": "Public",
           "unlisted": "Unlisted",
           "private": "Private",
@@ -340,7 +340,7 @@
       "l": "Switch focus to the right column",
       "r": "Reply to the post",
       "b": "Boost the post",
-      "f": "Favourite the post",
+      "f": "Favorite the post",
       "o": "Open the post's details",
       "p": "Display the profile of the post's author",
       "i": "Open the images",
@@ -487,8 +487,8 @@
     "find_account_error": "Account not found",
     "reblog_error": "Failed to boost",
     "unreblog_error": "Failed to unboost",
-    "favourite_error": "Failed to favourite",
-    "unfavourite_error": "Failed to unfavourite",
+    "favourite_error": "Failed to favorite",
+    "unfavourite_error": "Failed to unfavorite",
     "bookmark_error": "Failed to bookmark",
     "unbookmark_error": "Failed to remove bookmark",
     "delete_error": "Failed to delete the post",
@@ -519,8 +519,8 @@
   },
   "notification": {
     "favourite": {
-      "title": "New favourite",
-      "body": "{{username}} favourited your post"
+      "title": "New favorite",
+      "body": "{{username}} favorited your post"
     },
     "follow": {
       "title": "New follower",

--- a/src/config/locales/en/translation.json
+++ b/src/config/locales/en/translation.json
@@ -90,7 +90,7 @@
       "toot": {
         "title": "Posts",
         "visibility": {
-          "description": "Customize default visibility of post",
+          "description": "Default post visibility",
           "notice": "This setting applies only to new posts; replies will follow the visibility settings of the parent post.",
           "public": "Public",
           "unlisted": "Unlisted",
@@ -227,7 +227,7 @@
         "reaction": "Emoji reactions",
         "follow_request": "Follow requests",
         "status": "Status notifications",
-        "poll_vote": "When someone votes in a poll",
+        "poll_vote": "Poll votes",
         "poll_expired": "When a poll expires"
       }
     },
@@ -242,7 +242,7 @@
       "remove_all_associations": "Remove all associations",
       "confirm": "Confirm",
       "cancel": "Cancel",
-      "confirm_message": "Are you sure to remove all associations?"
+      "confirm_message": "Are you sure you want to remove all associations?"
     },
     "network": {
       "title": "Network",
@@ -296,7 +296,7 @@
         "change_visibility": "Change visibility",
         "change_sensitive": "Mark media as sensitive",
         "add_cw": "Add content warnings",
-        "pined_hashtag": "Pin a hashtag"
+        "pined_hashtag": "Pinned hashtag"
       },
       "poll": {
         "add_choice": "Add an option",
@@ -338,13 +338,13 @@
       "k": "Select the previous post",
       "h": "Switch focus to the left column",
       "l": "Switch focus to the right column",
-      "r": "Reply to the post",
-      "b": "Boost the post",
-      "f": "Favorite the post",
-      "o": "Open the post's details",
-      "p": "Display the profile of the post's author",
-      "i": "Open the images",
-      "x": "Expand/hide content warned posts",
+      "r": "Reply to the selected post",
+      "b": "Boost the selected post",
+      "f": "Favorite the selected post",
+      "o": "View the selected post's details",
+      "p": "Display the profile of the selected post's author",
+      "i": "Open the selected post's images",
+      "x": "Show/hide a content warned post",
       "?": "Show this dialog",
       "esc": "Close current page"
     },
@@ -399,8 +399,8 @@
       "detail": "Detail",
       "follow": "Follow this user",
       "unfollow": "Unfollow this user",
-      "subscribe": "Subscribe this user",
-      "unsubscribe": "Unsubscribe this user",
+      "subscribe": "Subscribe to this user",
+      "unsubscribe": "Unsubscribe from this user",
       "follow_requested": "Follow requested",
       "open_in_browser": "Open in browser",
       "manage_list_memberships": "Manage list memberships",

--- a/src/config/locales/en/translation.json
+++ b/src/config/locales/en/translation.json
@@ -52,7 +52,7 @@
     "notification": "Notifications",
     "direct": "Direct messages",
     "follow_requests": "Follow requests",
-    "favourite": "Favorited",
+    "favourite": "Favourited",
     "bookmark": "Bookmarks",
     "local": "Local timeline",
     "public": "Public timeline",
@@ -63,7 +63,7 @@
   "header_menu": {
     "home": "Home",
     "notification": "Notifications",
-    "favourite": "Favorited",
+    "favourite": "Favourited",
     "bookmark": "Bookmarks",
     "follow_requests": "Follow requests",
     "direct_messages": "Direct messages",
@@ -158,7 +158,7 @@
       "sounds": {
         "title": "Sounds",
         "description": "Play sounds when",
-        "fav_rb": "You favorite or boost a post",
+        "fav_rb": "You favourite or boost a post",
         "toot": "You make a post"
       },
       "timeline": {
@@ -179,7 +179,7 @@
     },
     "appearance": {
       "title": "Appearance",
-      "theme_color": "Theme color",
+      "theme_color": "Colour themes",
       "theme": {
         "system": "System",
         "light": "Light",
@@ -222,7 +222,7 @@
         "description": "Notify me when I receive...",
         "reply": "Replies",
         "reblog": "Boosts",
-        "favourite": "Favorites",
+        "favourite": "Favourites",
         "follow": "New followers",
         "reaction": "Emoji reactions",
         "follow_request": "Follow requests",
@@ -340,7 +340,7 @@
       "l": "Switch focus to the right column",
       "r": "Reply to the selected post",
       "b": "Boost the selected post",
-      "f": "Favorite the selected post",
+      "f": "Favourite the selected post",
       "o": "View the selected post's details",
       "p": "Display the profile of the selected post's author",
       "i": "Open the selected post's images",
@@ -370,7 +370,7 @@
       "via": "via {{application}}",
       "reply": "Reply",
       "reblog": "Boost",
-      "fav": "Favorite",
+      "fav": "Favourite",
       "detail": "Post details",
       "bookmark": "Bookmark",
       "pinned": "Pinned post",
@@ -466,7 +466,7 @@
     "preferences_load_error": "Failed to load preferences",
     "timeline_fetch_error": "Failed to fetch timeline",
     "notification_fetch_error": "Failed to fetch notification",
-    "favourite_fetch_error": "Failed to fetch favorite",
+    "favourite_fetch_error": "Failed to fetch favourite",
     "bookmark_fetch_error": "Failed to fetch bookmarks",
     "follow_request_accept_error": "Failed to accept the request",
     "follow_request_reject_error": "Failed to reject the request",
@@ -487,8 +487,8 @@
     "find_account_error": "Account not found",
     "reblog_error": "Failed to boost",
     "unreblog_error": "Failed to unboost",
-    "favourite_error": "Failed to favorite",
-    "unfavourite_error": "Failed to unfavorite",
+    "favourite_error": "Failed to favourite",
+    "unfavourite_error": "Failed to unfavourite",
     "bookmark_error": "Failed to bookmark",
     "unbookmark_error": "Failed to remove bookmark",
     "delete_error": "Failed to delete the post",
@@ -519,8 +519,8 @@
   },
   "notification": {
     "favourite": {
-      "title": "New favorite",
-      "body": "{{username}} favorited your post"
+      "title": "New favourite",
+      "body": "{{username}} favourited your post"
     },
     "follow": {
       "title": "New follower",


### PR DESCRIPTION
## Description
Cleaned up the wording on some of the strings used in the English localization; most of them were changes in terminology to match other Mastodon apps and the main web UI, including changing "toot" to "post", and "reblog" to "boost". I also cleaned up other strings to have a better flow and be more descriptive of what they do.

I also changed "favourite" to "favorite" because it seemed to be inconsistent on whether it was trying to be ``en-US`` or ``en-GB`` (i.e. using "color" but "favourite"; we should just add British English as a separate option).