### PR TITLE
Stop building universal dmg for a while

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -37,8 +37,7 @@
         "target": "dmg",
         "arch": [
           "x64",
-          "arm64",
-          "universal"
+          "arm64"
         ]
       }
     ],
@@ -49,9 +48,6 @@
     "hardenedRuntime": true,
     "gatekeeperAssess": false,
     "darkModeSupport": true,
-    "extendInfo": {
-      "ITSAppUsesNonExemptEncryption": "false"
-    },
     "mergeASARs": false,
     "asarUnpack": "node_modules/**/*.node"
   },


### PR DESCRIPTION
## Description
Because it has an invalid native dependency build.
It contains arm64 build even if x64 build.

## Related Issues
refs #4220 

## Appearance
<!-- If you change the appearance, please paste the screenshots. -->
