### PR TITLE
modify .el-checkbox color

### DIFF
--- a/src/renderer/components/Preferences/Language.vue
+++ b/src/renderer/components/Preferences/Language.vue
@@ -124,6 +124,10 @@ export default defineComponent({
     color: var(--theme-primary-color);
   }
 
+  #spellcheck_languages .el-checkbox {
+    color: var(--theme-regular-color);
+  }
+
   .selection {
     margin: 12px 0;
 


### PR DESCRIPTION
## Description
The label text was difficult to see when using the dark theme, so I replaced its color with `--theme-regular-color`.

## Related Issues
None

## Appearance
### Before
![スクリーンショット 2023-07-09 150646](https://github.com/h3poteto/whalebird-desktop/assets/73807432/5f91ec01-37b7-43e8-ad16-cd7d24ee0d31)

### After
![スクリーンショット 2023-07-09 150720](https://github.com/h3poteto/whalebird-desktop/assets/73807432/76ad8e51-c69a-4782-b745-f0001801e655)
