### PR TITLE
TONS of CSS changes to prettify the main view

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -88,7 +88,7 @@ body,
     color: #409eff;
   }
 
-  --toot-padding: 8px;
+  --toot-padding: 4px;
   --base-font-size: 14px;
 
   font-size: var(--base-font-size);
@@ -138,8 +138,12 @@ body,
   }
 }
 
+p:first-child, p:last-child {
+  margin: 0;
+}
+
 p {
-  margin: 8px 0;
+  margin: 5px 0px;
 }
 
 .clearfix::after {

--- a/src/renderer/assets/fonts/fonts.css
+++ b/src/renderer/assets/fonts/fonts.css
@@ -9,3 +9,35 @@
 		url("./NotoSans-Regular.ttf") format("truetype");
 }
 
+/* === Noto Sans - bold */
+@font-face {
+	font-family: 'Noto Sans';
+	font-style: normal;
+	font-weight: 700;
+	src: url("./NotoSans-Bold.ttf");
+	src: local("Noto Sans Bold"),
+		local("NotoSans-Bold"),
+		url("./NotoSans-Bold.ttf") format("truetype");
+}
+
+/* === Noto Sans - bold italic */
+@font-face {
+	font-family: 'Noto Sans';
+	font-style: italic;
+	font-weight: 700;
+	src: url("./NotoSans-BoldItalic.ttf");
+	src: local("Noto Sans BoldItalic"),
+		local("NotoSans-BoldItalic"),
+		url("./NotoSans-BoldItalic.ttf") format("truetype");
+}
+
+/* === Noto Sans - italic */
+@font-face {
+	font-family: 'Noto Sans';
+	font-style: italic;
+	font-weight: 400;
+	src: url("./NotoSans-Italic.ttf");
+	src: local("Noto Sans Italic"),
+		local("NotoSans-Italic"),
+		url("./NotoSans-Italic.ttf") format("truetype");
+}

--- a/src/renderer/components/GlobalHeader.vue
+++ b/src/renderer/components/GlobalHeader.vue
@@ -93,14 +93,13 @@ export default defineComponent({
 .account-menu :deep(.el-menu-item) {
   display: flex;
   justify-content: center;
-  align-items: flex-end;
   padding: 0 !important;
 }
 
 #global_header {
   .account-menu {
     height: 100%;
-    padding-top: 24px;
+    padding-top: 12px;
     border: 0;
 
     .avatar {
@@ -115,7 +114,8 @@ export default defineComponent({
       height: 18px;
       mix-blend-mode: overlay;
       vertical-align: bottom;
-      margin-left: -18px;
+      margin-left: -16px;
+      margin-bottom: -24px;
     }
 
     .is-active {

--- a/src/renderer/components/TimelineSpace/SideMenu.vue
+++ b/src/renderer/components/TimelineSpace/SideMenu.vue
@@ -421,7 +421,7 @@ export default defineComponent({
 #side_menu {
   .profile-wrapper {
     background-color: var(--theme-side-menu-color);
-    width: 180px;
+    width: 200px;
     height: 82px;
     font-size: 16px;
     display: flex;
@@ -517,7 +517,7 @@ export default defineComponent({
 
   .timeline-menu {
     height: calc(100% - 82px);
-    width: 180px;
+    width: 200px;
     border: none;
     overflow-x: hidden;
 
@@ -540,11 +540,16 @@ export default defineComponent({
     .menu-item {
       display: flex;
       align-items: center;
+      height: 44px;
 
       .menu-item-icon {
         text-align: center;
-        padding-right: 2px;
+        padding-right: 6px;
         width: 18px;
+
+        svg {
+          width: var(--fa-fw-width, 1.25em);
+        }
       }
     }
 

--- a/src/renderer/components/molecules/Toot/LinkPreview.vue
+++ b/src/renderer/components/molecules/Toot/LinkPreview.vue
@@ -54,7 +54,7 @@ export default defineComponent({
   display: flex;
   border-radius: 4px;
   overflow: hidden;
-  margin-bottom: 4px;
+  margin-bottom: 8px;
   border: 1px solid var(--theme-selected-background-color);
   cursor: pointer;
 
@@ -83,7 +83,7 @@ export default defineComponent({
   .contents {
     box-sizing: border-box;
     height: 60px;
-    padding: 4px 0 0 10px;
+    padding: 8px 11px;
     color: var(--theme-secondary-color);
     overflow: hidden;
 

--- a/src/renderer/components/organisms/Toot.vue
+++ b/src/renderer/components/organisms/Toot.vue
@@ -756,7 +756,7 @@ export default defineComponent({
 }
 
 .toot {
-  padding: 8px 0 0 16px;
+  padding: 8px 0 5px 16px;
   position: relative;
 
   .fa-icon {
@@ -771,6 +771,7 @@ export default defineComponent({
     float: left;
 
     img {
+      margin-top: 3px;
       width: 36px;
       height: 36px;
       border-radius: 4px;
@@ -788,7 +789,7 @@ export default defineComponent({
     .reblogger-icon {
       width: 16px;
       height: 16px;
-      margin: 0 4px;
+      margin-right: 8px;
 
       img {
         width: 16px;
@@ -865,8 +866,9 @@ export default defineComponent({
         }
 
         .display-name :deep(.emojione) {
-          max-width: 14px;
-          max-height: 14px;
+          max-width: 16px;
+          max-height: 16px;
+          vertical-align: sub;
         }
 
         .acct {
@@ -966,9 +968,13 @@ export default defineComponent({
 
       button {
         display: block;
-        padding: 4px 8px;
+        padding: 4px 12px;
         margin: 0;
         color: #909399;
+      }
+
+      button:first-child {
+        padding-left: 0px;
       }
 
       .reblogged {


### PR DESCRIPTION
## Description
I did this because I realized there were quite a few adjustments I wanted to make to the appearance of the app that were not available to be adjusted in the settings panel.

Summary of changes:
- Fix bug where Noto Sans bold was not working
- Adjust padding and such with GlobalHeader so that the hover effect works properly
- Overhaul the margins of toots
- Add fa-fw to the icons in the sidemenu to fix text alignment
- Make side menu sizes smaller

## Appearance
<img width="1624" alt="image" src="https://github.com/h3poteto/whalebird-desktop/assets/22629722/505e0c56-06ef-4242-81c6-c46da1bcd707">
