### PR TITLE
Revert "Update dependency electron-serve to v2"

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "blurhash": "^2.0.5",
     "dayjs": "^1.11.10",
     "dexie": "^4.0.0",
-    "electron-serve": "^2.0.0",
+    "electron-serve": "^1.1.0",
     "electron-store": "^8.1.0",
     "emoji-mart": "^5.5.2",
     "megalodon": "10.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2777,7 +2777,7 @@ __metadata:
     dexie: ^4.0.0
     electron: 28
     electron-builder: ^24.6.4
-    electron-serve: ^2.0.0
+    electron-serve: ^1.1.0
     electron-store: ^8.1.0
     electron-windows-store: ^2.1.0
     emoji-mart: ^5.5.2
@@ -4290,10 +4290,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-serve@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "electron-serve@npm:2.0.0"
-  checksum: 3cbd5641bba30897ddbad3bcd83a0ce79075d5524f23f0bf4eba90d72c16200b7f08d32c61095bee4e8060ea6ebe240ce1e87f9359da90b4bd035a2b6693611f
+"electron-serve@npm:^1.1.0":
+  version: 1.3.0
+  resolution: "electron-serve@npm:1.3.0"
+  checksum: 06db8d1d71f866abc2dbe62ea5b50c1e467383d18f598e856e2c54d709dfdea255203c9d52397b4d4bb476cb5f336626a88cf5e0a1cb64488a7ff70b01d4a828
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reverts h3poteto/whalebird-desktop#4937

```
A JavaScript error occurred in the main process
Uncaught Exception:
Error [ERR_REQUIRE_ESM]: require() of ES Module /run/media/h3poteto/ssd1/dev/src/github.com/h3poteto/whalebird-desktop/node_modules/electron-serve/index.js from /run/media/h3poteto/ssd1/dev/src/github.com/h3poteto/whalebird-desktop/app/background.js not supported.
Instead change the require of index.js in /run/media/h3poteto/ssd1/dev/src/github.com/h3poteto/whalebird-desktop/app/background.js to a dynamic import() which is available in all CommonJS modules.
    at c._load (node:electron/js2c/node_init:2:13672)
    at webpackUniversalModuleDefinition (/run/media/h3poteto/ssd1/dev/src/github.com/h3poteto/whalebird-desktop/app/background.js:3:28)
    at Object.<anonymous> (/run/media/h3poteto/ssd1/dev/src/github.com/h3poteto/whalebird-desktop/app/background.js:10:3)
    at c._load (node:electron/js2c/node_init:2:13672)
```